### PR TITLE
 Improve CLI feedback and documentation for checksum checking and repair

### DIFF
--- a/scripts/check-checksums
+++ b/scripts/check-checksums
@@ -24,13 +24,15 @@ import sys
 
 import structlog
 
-from npg_irods.utilities import check_checksums, check_common_metadata
+from npg_irods.utilities import check_checksums
 from npg_irods.version import version
 
 description = """
 Reads iRODS data object paths from a file or STDIN, one per line and performs
 consistency checks on their iRODS checksums and checksum metadata.
-"""
+
+If any of the paths fail their checksum check, the exit code will be non-zero and an 
+error message summarising the results will be sent to STDERR. """
 
 parser = argparse.ArgumentParser(
     description=description, formatter_class=argparse.RawDescriptionHelpFormatter

--- a/scripts/check-checksums
+++ b/scripts/check-checksums
@@ -65,6 +65,18 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--json",
+    help="Use JSON log rendering.",
+    action="store_true",
+)
+
+parser.add_argument(
+    "--colour",
+    help="Use coloured log rendering to the console",
+    action="store_true",
+)
+
+parser.add_argument(
     "-c",
     "--clients",
     help="Number of baton clients to use. Defaults to 4",
@@ -102,7 +114,22 @@ logging.basicConfig(
     encoding="utf-8",
 )
 
-structlog.configure(logger_factory=structlog.stdlib.LoggerFactory())
+log_processors = [
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.processors.TimeStamper(fmt="iso", utc=True),
+]
+if args.json:
+    log_processors.append(structlog.processors.JSONRenderer())
+else:
+    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
+
+structlog.configure(
+    processors=log_processors,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    cache_logger_on_first_use=True,
+)
+
 log = structlog.get_logger("main")
 
 
@@ -111,7 +138,7 @@ def main():
         print(version())
         exit(0)
 
-    success = check_checksums(
+    num_processed, num_passed, num_errors = check_checksums(
         args.input,
         args.output,
         print_pass=args.print_pass,
@@ -119,8 +146,22 @@ def main():
         num_clients=args.clients,
         num_threads=args.threads,
     )
-    if not success:
+
+    if num_errors:
+        log.error(
+            "Some checks did not pass",
+            num_processed=num_processed,
+            num_passed=num_passed,
+            num_errors=num_errors,
+        )
         exit(1)
+
+    log.info(
+        "All checks passed",
+        num_processed=num_processed,
+        num_passed=num_passed,
+        num_errors=num_errors,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/repair-checksums
+++ b/scripts/repair-checksums
@@ -65,6 +65,19 @@ parser.add_argument(
     action="store_true",
 )
 
+
+parser.add_argument(
+    "--json",
+    help="Use JSON log rendering.",
+    action="store_true",
+)
+
+parser.add_argument(
+    "--colour",
+    help="Use coloured log rendering to the console",
+    action="store_true",
+)
+
 parser.add_argument(
     "-c",
     "--clients",
@@ -104,7 +117,23 @@ logging.basicConfig(
     encoding="utf-8",
 )
 
-structlog.configure(logger_factory=structlog.stdlib.LoggerFactory())
+
+log_processors = [
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.processors.TimeStamper(fmt="iso", utc=True),
+]
+if args.json:
+    log_processors.append(structlog.processors.JSONRenderer())
+else:
+    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
+
+structlog.configure(
+    processors=log_processors,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    cache_logger_on_first_use=True,
+)
+
 log = structlog.get_logger("main")
 
 
@@ -113,7 +142,7 @@ def main():
         print(version())
         exit(0)
 
-    success = repair_checksums(
+    num_processed, num_repaired, num_errors = repair_checksums(
         args.input,
         args.output,
         num_threads=args.threads,
@@ -122,8 +151,29 @@ def main():
         print_fail=args.print_fail,
     )
 
-    if not success:
+    if num_errors:
+        log.error(
+            "Some repairs did not succeed",
+            num_processed=num_processed,
+            num_repaired=num_repaired,
+            num_errors=num_errors,
+        )
         exit(1)
+
+    if num_repaired:
+        log.info(
+            "All paths repaired",
+            num_processed=num_processed,
+            num_repaired=num_repaired,
+            num_errors=num_errors,
+        )
+    else:
+        log.info(
+            "No paths required repair",
+            num_processed=num_processed,
+            num_repaired=num_repaired,
+            num_errors=num_errors,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/repair-checksums
+++ b/scripts/repair-checksums
@@ -30,6 +30,10 @@ from npg_irods.version import version
 description = """
 Reads iRODS data object paths from a file or STDIN, one per line and repairs
 their checksums and checksum metadata, if necessary.
+
+If any of the paths initially fail their checksum check and could not be repaired,   
+the exit code will be non-zero and an error message summarising the results will be 
+sent to STDERR.
 """
 
 parser = argparse.ArgumentParser(

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -34,7 +34,7 @@ from npg_irods.utilities import check_checksums, copy, repair_checksums
 class TestUtilities:
     @m.context("When data object checksums are checked")
     @m.context("When all of the data objects have checksum metadata")
-    @m.it("Counts repairs correctly")
+    @m.it("Counts correct checksums correctly")
     def test_checked_checksums_passes(self, annotated_tree):
         obj_paths = []
         for p in Collection(annotated_tree).contents(recurse=True):


### PR DESCRIPTION
 Improve CLI feedback and documentation for checksum checking and repair

Add --colour and --json CLI options.
Add counting of items, errors, repairs.
Add summary information of errors to STDERR.

(These 2 commits should be squashed)