### PR TITLE
Add scripts to check and repair data object replicas 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/wtsi-npg/ml-warehouse-python.git@1.0.0#egg=ml-warehouse
-partisan@https://github.com/wtsi-npg/partisan/releases/download/2.0.0/partisan-2.0.0.tar.gz
+partisan@https://github.com/wtsi-npg/partisan/releases/download/2.1.0/partisan-2.1.0.tar.gz
 rich==12.6.0
 setuptools==67.3.3
 setuptools_scm==7.1.0

--- a/scripts/check-checksums
+++ b/scripts/check-checksums
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,70 +32,61 @@ Reads iRODS data object paths from a file or STDIN, one per line and performs
 consistency checks on their iRODS checksums and checksum metadata.
 
 If any of the paths fail their checksum check, the exit code will be non-zero and an 
-error message summarising the results will be sent to STDERR. """
+error message summarising the results will be sent to STDERR.
+"""
 
 parser = argparse.ArgumentParser(
     description=description, formatter_class=argparse.RawDescriptionHelpFormatter
 )
-
 parser.add_argument(
     "-i",
     "--input",
-    help="Input filename",
+    help="Input filename.",
     type=argparse.FileType("r"),
     default=sys.stdin,
 )
-
 parser.add_argument(
     "-o",
     "--output",
-    help="Output filename",
+    help="Output filename.",
     type=argparse.FileType("w"),
     default=sys.stdout,
 )
-
 parser.add_argument(
     "--print-pass",
     help="Print to output those paths that pass the check. Defaults to True.",
     action="store_true",
 )
-
 parser.add_argument(
     "--print-fail",
     help="Print to output those paths that fail the check. Defaults to False.",
     action="store_true",
 )
-
+parser.add_argument(
+    "--colour",
+    help="Use coloured log rendering to the console.",
+    action="store_true",
+)
 parser.add_argument(
     "--json",
     help="Use JSON log rendering.",
     action="store_true",
 )
-
-parser.add_argument(
-    "--colour",
-    help="Use coloured log rendering to the console",
-    action="store_true",
-)
-
 parser.add_argument(
     "-c",
     "--clients",
-    help="Number of baton clients to use. Defaults to 4",
+    help="Number of baton clients to use. Defaults to 4.",
     type=int,
     default=4,
 )
-
 parser.add_argument(
     "-t",
     "--threads",
-    help="Number of threads to use. Defaults to 4",
+    help="Number of threads to use. Defaults to 4.",
     type=int,
     default=4,
 )
-
 parser.add_argument("--version", help="Print the version and exit", action="store_true")
-
 parser.add_argument(
     "-d", "--debug", help="Enable DEBUG level logging to STDERR", action="store_true"
 )

--- a/scripts/check-common-metadata
+++ b/scripts/check-common-metadata
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,53 +41,55 @@ consistency checks on their metadata.
 parser = argparse.ArgumentParser(
     description=description, formatter_class=argparse.RawDescriptionHelpFormatter
 )
-
 parser.add_argument(
     "-i",
     "--input",
-    help="Input filename",
+    help="Input filename.",
     type=argparse.FileType("r"),
     default=sys.stdin,
 )
-
 parser.add_argument(
     "-o",
     "--output",
-    help="Output filename",
+    help="Output filename.",
     type=argparse.FileType("w"),
     default=sys.stdout,
 )
-
 parser.add_argument(
     "--print-pass",
     help="Print to output those paths that pass the check. Defaults to True.",
     action="store_true",
 )
-
 parser.add_argument(
     "--print-fail",
     help="Print to output those paths that fail the check. Defaults to False.",
     action="store_true",
 )
-
+parser.add_argument(
+    "--json",
+    help="Use JSON log rendering.",
+    action="store_true",
+)
+parser.add_argument(
+    "--colour",
+    help="Use coloured log rendering to the console.",
+    action="store_true",
+)
 parser.add_argument(
     "-c",
     "--clients",
-    help="Number of baton clients to use. Defaults to 4",
+    help="Number of baton clients to use. Defaults to 4.",
     type=int,
     default=4,
 )
-
 parser.add_argument(
     "-t",
     "--threads",
-    help="Number of threads to use. Defaults to 4",
+    help="Number of threads to use. Defaults to 4.",
     type=int,
     default=4,
 )
-
 parser.add_argument("--version", help="Print the version and exit", action="store_true")
-
 parser.add_argument(
     "-d", "--debug", help="Enable DEBUG level logging to STDERR", action="store_true"
 )
@@ -108,7 +110,22 @@ logging.basicConfig(
     encoding="utf-8",
 )
 
-structlog.configure(logger_factory=structlog.stdlib.LoggerFactory())
+log_processors = [
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.processors.TimeStamper(fmt="iso", utc=True),
+]
+if args.json:
+    log_processors.append(structlog.processors.JSONRenderer())
+else:
+    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
+
+structlog.configure(
+    processors=log_processors,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    cache_logger_on_first_use=True,
+)
+
 log = structlog.get_logger("main")
 
 

--- a/scripts/check-replicas
+++ b/scripts/check-replicas
@@ -24,74 +24,76 @@ import sys
 
 import structlog
 
-from npg_irods.utilities import check_checksums, check_replicas
+from npg_irods.utilities import check_replicas
 from npg_irods.version import version
 
 description = """
+Reads iRODS data object paths from a file or STDIN, one per line and performs
+consistency checks on their iRODS replicas.
+
+If any of the paths fail their replica check, the exit code will be non-zero and an 
+error message summarising the results will be sent to STDERR.
 """
 
 parser = argparse.ArgumentParser(
     description=description, formatter_class=argparse.RawDescriptionHelpFormatter
 )
-
 parser.add_argument(
     "-i",
     "--input",
-    help="Input filename",
+    help="Input filename.",
     type=argparse.FileType("r"),
     default=sys.stdin,
 )
-
 parser.add_argument(
     "-o",
     "--output",
-    help="Output filename",
+    help="Output filename.",
     type=argparse.FileType("w"),
     default=sys.stdout,
 )
-
+parser.add_argument(
+    "-n",
+    "--num-replicas",
+    help="The number of valid replicas expected. Defaults to 2.",
+    type=int,
+    default=2,
+)
 parser.add_argument(
     "--print-pass",
     help="Print to output those paths that pass the check. Defaults to True.",
     action="store_true",
 )
-
 parser.add_argument(
     "--print-fail",
     help="Print to output those paths that fail the check. Defaults to False.",
     action="store_true",
 )
-
+parser.add_argument(
+    "--colour",
+    help="Use coloured log rendering to the console.",
+    action="store_true",
+)
 parser.add_argument(
     "--json",
     help="Use JSON log rendering.",
     action="store_true",
 )
-
-parser.add_argument(
-    "--colour",
-    help="Use coloured log rendering to the console",
-    action="store_true",
-)
-
 parser.add_argument(
     "-c",
     "--clients",
-    help="Number of baton clients to use. Defaults to 4",
+    help="Number of baton clients to use. Defaults to 4.",
     type=int,
     default=4,
 )
-
 parser.add_argument(
     "-t",
     "--threads",
-    help="Number of threads to use. Defaults to 4",
+    help="Number of threads to use. Defaults to 4.",
     type=int,
     default=4,
 )
-
 parser.add_argument("--version", help="Print the version and exit", action="store_true")
-
 parser.add_argument(
     "-d", "--debug", help="Enable DEBUG level logging to STDERR", action="store_true"
 )
@@ -139,6 +141,7 @@ def main():
     num_processed, num_passed, num_errors = check_replicas(
         args.input,
         args.output,
+        num_replicas=args.num_replicas,
         print_pass=args.print_pass,
         print_fail=args.print_fail,
         num_clients=args.clients,

--- a/scripts/check-replicas
+++ b/scripts/check-replicas
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2023 Genome Research Ltd. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# @author Keith James <kdj@sanger.ac.uk>
+
+import argparse
+import logging
+import sys
+
+import structlog
+
+from npg_irods.utilities import check_checksums, check_replicas
+from npg_irods.version import version
+
+description = """
+"""
+
+parser = argparse.ArgumentParser(
+    description=description, formatter_class=argparse.RawDescriptionHelpFormatter
+)
+
+parser.add_argument(
+    "-i",
+    "--input",
+    help="Input filename",
+    type=argparse.FileType("r"),
+    default=sys.stdin,
+)
+
+parser.add_argument(
+    "-o",
+    "--output",
+    help="Output filename",
+    type=argparse.FileType("w"),
+    default=sys.stdout,
+)
+
+parser.add_argument(
+    "--print-pass",
+    help="Print to output those paths that pass the check. Defaults to True.",
+    action="store_true",
+)
+
+parser.add_argument(
+    "--print-fail",
+    help="Print to output those paths that fail the check. Defaults to False.",
+    action="store_true",
+)
+
+parser.add_argument(
+    "--json",
+    help="Use JSON log rendering.",
+    action="store_true",
+)
+
+parser.add_argument(
+    "--colour",
+    help="Use coloured log rendering to the console",
+    action="store_true",
+)
+
+parser.add_argument(
+    "-c",
+    "--clients",
+    help="Number of baton clients to use. Defaults to 4",
+    type=int,
+    default=4,
+)
+
+parser.add_argument(
+    "-t",
+    "--threads",
+    help="Number of threads to use. Defaults to 4",
+    type=int,
+    default=4,
+)
+
+parser.add_argument("--version", help="Print the version and exit", action="store_true")
+
+parser.add_argument(
+    "-d", "--debug", help="Enable DEBUG level logging to STDERR", action="store_true"
+)
+parser.add_argument(
+    "-v", "--verbose", help="Enable INFO level logging to STDERR", action="store_true"
+)
+
+args = parser.parse_args()
+
+level = logging.ERROR
+if args.debug:
+    level = logging.DEBUG
+elif args.verbose:
+    level = logging.INFO
+
+logging.basicConfig(
+    level=level,
+    encoding="utf-8",
+)
+
+log_processors = [
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.processors.TimeStamper(fmt="iso", utc=True),
+]
+if args.json:
+    log_processors.append(structlog.processors.JSONRenderer())
+else:
+    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
+
+structlog.configure(
+    processors=log_processors,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    cache_logger_on_first_use=True,
+)
+
+log = structlog.get_logger("main")
+
+
+def main():
+    if args.version:
+        print(version())
+        exit(0)
+
+    num_processed, num_passed, num_errors = check_replicas(
+        args.input,
+        args.output,
+        print_pass=args.print_pass,
+        print_fail=args.print_fail,
+        num_clients=args.clients,
+        num_threads=args.threads,
+    )
+
+    if num_errors:
+        log.error(
+            "Some checks did not pass",
+            num_processed=num_processed,
+            num_passed=num_passed,
+            num_errors=num_errors,
+        )
+        exit(1)
+
+    log.info(
+        "All checks passed",
+        num_processed=num_processed,
+        num_passed=num_passed,
+        num_errors=num_errors,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/copy-confirm
+++ b/scripts/copy-confirm
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -46,63 +46,53 @@ abort further copying until the problem is resolved.
 parser = argparse.ArgumentParser(
     description=description, formatter_class=argparse.RawDescriptionHelpFormatter
 )
-
 parser.add_argument(
     "source",
-    help="Collection or data object path to copy from. Must be an absolute path",
+    help="Collection or data object path to copy from. Must be an absolute path.",
 )
-
 parser.add_argument(
     "destination",
-    help="Collection or data object path to copy to. Must be an absolute path",
+    help="Collection or data object path to copy to. Must be an absolute path.",
 )
-
-parser.add_argument(
-    "--colour",
-    help="Use coloured log rendering to the console",
-    action="store_true",
-)
-
 parser.add_argument(
     "--copy-metadata",
-    help="Copy the AVUs (metadata) of each data object and collection",
+    help="Copy the AVUs (metadata) of each data object and collection.",
     action="store_true",
 )
-
 parser.add_argument(
     "--copy-permissions",
     help="Copy the ACL (access control list, permissions) of each data object "
-    "and collection",
+    "and collection.",
     action="store_true",
 )
-
-parser.add_argument(
-    "--json",
-    help="Use JSON log rendering.",
-    action="store_true",
-)
-
 parser.add_argument(
     "--recurse",
     help="Recurse into collections when copying.",
     action="store_true",
 )
-
 parser.add_argument(
     "--skip-existing",
-    help="Skip existing data objects and collections when copying",
+    help="Skip existing data objects and collections when copying.",
     action="store_true",
 )
-
+parser.add_argument(
+    "--colour",
+    help="Use coloured log rendering to the console.",
+    action="store_true",
+)
+parser.add_argument(
+    "--json",
+    help="Use JSON log rendering.",
+    action="store_true",
+)
 parser.add_argument(
     "--version", help="Print the version and exit.", action="store_true"
 )
-
 parser.add_argument(
-    "-d", "--debug", help="Enable DEBUG level logging to STDERR", action="store_true"
+    "-d", "--debug", help="Enable DEBUG level logging to STDERR.", action="store_true"
 )
 parser.add_argument(
-    "-v", "--verbose", help="Enable INFO level logging to STDERR", action="store_true"
+    "-v", "--verbose", help="Enable INFO level logging to STDERR.", action="store_true"
 )
 
 args = parser.parse_args()

--- a/scripts/repair-common-metadata
+++ b/scripts/repair-common-metadata
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,68 +41,69 @@ their metadata, if necessary.
 parser = argparse.ArgumentParser(
     description=description, formatter_class=argparse.RawDescriptionHelpFormatter
 )
-
 parser.add_argument(
     "-i",
     "--input",
-    help="Input filename",
+    help="Input filename.",
     type=argparse.FileType("r"),
     default=sys.stdin,
 )
-
 parser.add_argument(
     "-o",
     "--output",
-    help="Output filename",
+    help="Output filename.",
     type=argparse.FileType("w"),
     default=sys.stdout,
 )
-
 parser.add_argument(
     "--print-repair",
     help="Print to output those paths that were repaired. Defaults to True.",
     action="store_true",
 )
-
 parser.add_argument(
     "--print-fail",
     help="Print to output those paths that require repair, where the repair failed. "
     "Defaults to False.",
     action="store_true",
 )
-
+parser.add_argument(
+    "--colour",
+    help="Use coloured log rendering to the console.",
+    action="store_true",
+)
+parser.add_argument(
+    "--json",
+    help="Use JSON log rendering.",
+    action="store_true",
+)
 parser.add_argument(
     "-c",
     "--clients",
-    help="Number of baton clients to use. Defaults to 4",
+    help="Number of baton clients to use. Defaults to 4.",
     type=int,
     default=4,
 )
-
-
 parser.add_argument(
     "--creator",
     help="The data creator name to use in any metadata generated. "
     "Defaults to a placeholder value.",
     type=str,
 )
-
-
 parser.add_argument(
     "-t",
     "--threads",
-    help="Number of threads to use. Defaults to 4",
+    help="Number of threads to use. Defaults to 4.",
     type=int,
     default=4,
 )
-
-parser.add_argument("--version", help="Print the version and exit", action="store_true")
-
 parser.add_argument(
-    "-d", "--debug", help="Enable DEBUG level logging to STDERR", action="store_true"
+    "--version", help="Print the version and exit.", action="store_true"
 )
 parser.add_argument(
-    "-v", "--verbose", help="Enable INFO level logging to STDERR", action="store_true"
+    "-d", "--debug", help="Enable DEBUG level logging to STDERR.", action="store_true"
+)
+parser.add_argument(
+    "-v", "--verbose", help="Enable INFO level logging to STDERR.", action="store_true"
 )
 
 args = parser.parse_args()
@@ -118,7 +119,22 @@ logging.basicConfig(
     encoding="utf-8",
 )
 
-structlog.configure(logger_factory=structlog.stdlib.LoggerFactory())
+log_processors = [
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.processors.TimeStamper(fmt="iso", utc=True),
+]
+if args.json:
+    log_processors.append(structlog.processors.JSONRenderer())
+else:
+    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
+
+structlog.configure(
+    processors=log_processors,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    cache_logger_on_first_use=True,
+)
+
 log = structlog.get_logger("main")
 
 

--- a/scripts/repair-replicas
+++ b/scripts/repair-replicas
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022, 2023 Genome Research Ltd. All rights reserved.
+# Copyright © 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,14 +24,15 @@ import sys
 
 import structlog
 
-from npg_irods.utilities import repair_checksums
+from npg_irods.utilities import repair_replicas
 from npg_irods.version import version
 
 description = """
-Reads iRODS data object paths from a file or STDIN, one per line and repairs
-their checksums and checksum metadata, if necessary.
+Reads iRODS data object paths from a file or STDIN, one per line and repairs their
+replicas, if necessary. This means trimming any invalid replicas and/or excess valid
+replicas.
 
-If any of the paths initially fail their checksum check and could not be repaired,   
+If any of the paths initially fail their replica check and could not be repaired,   
 the exit code will be non-zero and an error message summarising the results will be 
 sent to STDERR.
 """
@@ -52,6 +53,13 @@ parser.add_argument(
     help="Output filename.",
     type=argparse.FileType("w"),
     default=sys.stdout,
+)
+parser.add_argument(
+    "-n",
+    "--num-replicas",
+    help="The number of valid replicas expected. Defaults to 2.",
+    type=int,
+    default=2,
 )
 parser.add_argument(
     "--print-repair",
@@ -111,7 +119,6 @@ logging.basicConfig(
     encoding="utf-8",
 )
 
-
 log_processors = [
     structlog.stdlib.add_logger_name,
     structlog.stdlib.add_log_level,
@@ -136,38 +143,31 @@ def main():
         print(version())
         exit(0)
 
-    num_processed, num_repaired, num_errors = repair_checksums(
+    num_processed, num_passed, num_errors = repair_replicas(
         args.input,
         args.output,
-        num_threads=args.threads,
-        num_clients=args.clients,
+        num_replicas=args.num_replicas,
         print_repair=args.print_repair,
         print_fail=args.print_fail,
+        num_clients=args.clients,
+        num_threads=args.threads,
     )
 
     if num_errors:
         log.error(
-            "Some repairs did not succeed",
+            "Some checks did not pass",
             num_processed=num_processed,
-            num_repaired=num_repaired,
+            num_passed=num_passed,
             num_errors=num_errors,
         )
         exit(1)
 
-    if num_repaired:
-        log.info(
-            "All paths repaired",
-            num_processed=num_processed,
-            num_repaired=num_repaired,
-            num_errors=num_errors,
-        )
-    else:
-        log.info(
-            "No paths required repair",
-            num_processed=num_processed,
-            num_repaired=num_repaired,
-            num_errors=num_errors,
-        )
+    log.info(
+        "All checks passed",
+        num_processed=num_processed,
+        num_passed=num_passed,
+        num_errors=num_errors,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/safe-remove-script
+++ b/scripts/safe-remove-script
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -48,52 +48,44 @@ Procedures e.g. be manually reviewed before use.
 parser = argparse.ArgumentParser(
     description=description, formatter_class=argparse.RawDescriptionHelpFormatter
 )
-
 parser.add_argument(
     "target",
     help="Target collection or data object path to remove, recursively if a "
-    "collection. Must be an absolute path",
+    "collection. Must be an absolute path.",
 )
-
 parser.add_argument(
     "-o",
     "--output",
-    help="Output filename",
+    help="Output filename.",
 )
-
 parser.add_argument(
     "--colour",
-    help="Use coloured log rendering to the console",
+    help="Use coloured log rendering to the console.",
     action="store_true",
 )
-
 parser.add_argument(
     "--json",
     help="Use JSON log rendering.",
     action="store_true",
 )
-
 parser.add_argument(
     "--echo-commands",
-    help="Create a script that echos each command executed",
+    help="Create a script that echos each command executed.",
     action="store_true",
 )
-
 parser.add_argument(
     "--stop-on-error",
-    help="Create a script that will stop on the first error encountered",
+    help="Create a script that will stop on the first error encountered.",
     action="store_true",
 )
-
 parser.add_argument(
     "--version", help="Print the version and exit.", action="store_true"
 )
-
 parser.add_argument(
-    "-d", "--debug", help="Enable DEBUG level logging to STDERR", action="store_true"
+    "-d", "--debug", help="Enable DEBUG level logging to STDERR.", action="store_true"
 )
 parser.add_argument(
-    "-v", "--verbose", help="Enable INFO level logging to STDERR", action="store_true"
+    "-v", "--verbose", help="Enable INFO level logging to STDERR.", action="store_true"
 )
 
 args = parser.parse_args()

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,12 @@ setup(
     scripts=[
         "scripts/backfill_illumina_locations.py",
         "scripts/check-checksums",
-        "scripts/check-replicas",
-        "scripts/repair-checksums",
         "scripts/check-common-metadata",
-        "scripts/repair-common-metadata",
+        "scripts/check-replicas",
         "scripts/copy-confirm",
+        "scripts/repair-checksums",
+        "scripts/repair-common-metadata",
+        "scripts/repair-replicas",
         "scripts/safe-remove-script",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     scripts=[
         "scripts/backfill_illumina_locations.py",
         "scripts/check-checksums",
+        "scripts/check-replicas",
         "scripts/repair-checksums",
         "scripts/check-common-metadata",
         "scripts/repair-common-metadata",

--- a/src/npg_irods/metadata/common.py
+++ b/src/npg_irods/metadata/common.py
@@ -289,13 +289,22 @@ def has_complete_replicas(obj: DataObject, num_replicas=2) -> bool:
 def trimmable_replicas(
     obj: DataObject, num_replicas=2
 ) -> (List[DataObject], List[DataObject]):
+    """Return tuple of lists of valid and invalid replicas that are trimmable.
+
+    Trimmable replicas are any valid replicas in excess of the expected number
+    and any invalid replicas (invalid replicas are always trimmable).
+
+    Args:
+        obj: The data object to check.
+        num_replicas: The expected number of valid replicas. Defaults to 2.
+
+    Returns:
+        A tuple of lists of replicas, those valid first.
+    """
     if num_replicas < 1:
         raise ValueError(
             f"The num_replicas argument may not be less than 1: {num_replicas}"
         )
-
-    if not has_complete_replicas(obj, num_replicas=num_replicas):
-        return [], []
 
     valid = []
     invalid = []
@@ -305,12 +314,24 @@ def trimmable_replicas(
         else:
             invalid.append(r)
 
-    return invalid, valid[num_replicas:]
+    return valid[num_replicas:], invalid
 
 
 def has_trimmable_replicas(obj: DataObject, num_replicas=2) -> bool:
-    invalid, valid = trimmable_replicas(obj, num_replicas=num_replicas)
-    return invalid or valid
+    """Return True if the data object has replicas that may be trimmed.
+
+    Trimmable replicas are any valid replicas in excess of the expected number
+    and any invalid replicas (invalid replicas are always trimmable).
+
+    Args:
+        obj: The data object to check.
+        num_replicas: The number of valid replicas that should be present.
+
+    Returns:
+        True if there are any replicas to trim.
+    """
+    valid, invalid = trimmable_replicas(obj, num_replicas=num_replicas)
+    return valid or invalid
 
 
 def requires_creation_metadata(obj: DataObject) -> bool:

--- a/src/npg_irods/metadata/common.py
+++ b/src/npg_irods/metadata/common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@
 from datetime import datetime
 from enum import unique
 from pathlib import PurePath
+from typing import List
 
 from partisan.irods import AVU, DataObject, RodsItem
 from partisan.metadata import AsValueEnum, DublinCore
@@ -260,6 +261,56 @@ def ensure_matching_checksum_metadata(obj: DataObject) -> bool:
         )
 
     return False
+
+
+def has_complete_replicas(obj: DataObject, num_replicas=2) -> bool:
+    """Return True if the data object has all required replicas.
+
+    This is defined as having at least the expected number of valid replicas, with
+    matching checksums on those that are valid.
+
+    Args:
+        obj: The data object to check.
+        num_replicas: The expected number of valid replicas. Defaults to 2.
+
+    Returns:
+        True if there are complete replicas, or False otherwise.
+    """
+    if num_replicas < 1:
+        raise ValueError(
+            f"The num_replicas argument may not be less than 1: {num_replicas}"
+        )
+
+    num_valid = len([r for r in obj.replicas() if r.valid])
+
+    return num_valid >= num_replicas and has_matching_checksums(obj)
+
+
+def trimmable_replicas(
+    obj: DataObject, num_replicas=2
+) -> (List[DataObject], List[DataObject]):
+    if num_replicas < 1:
+        raise ValueError(
+            f"The num_replicas argument may not be less than 1: {num_replicas}"
+        )
+
+    if not has_complete_replicas(obj, num_replicas=num_replicas):
+        return [], []
+
+    valid = []
+    invalid = []
+    for r in obj.replicas():
+        if r.valid:
+            valid.append(r)
+        else:
+            invalid.append(r)
+
+    return invalid, valid[num_replicas:]
+
+
+def has_trimmable_replicas(obj: DataObject, num_replicas=2) -> bool:
+    invalid, valid = trimmable_replicas(obj, num_replicas=num_replicas)
+    return invalid or valid
 
 
 def requires_creation_metadata(obj: DataObject) -> bool:

--- a/src/npg_irods/utilities.py
+++ b/src/npg_irods/utilities.py
@@ -338,11 +338,10 @@ def repair_replicas(
     - Valid replicas: if the data object has more valid replicas than the number
       required, the excess replicas are trimmed.
 
-
     Args:
         reader: A file supplying iRODS data object paths to repair, one per line.
         writer: A file where repaired paths will be written, one per line.
-        num_replicas:
+        num_replicas: The number of replicas expected. Defaults to 2.
         num_threads: The number of Python threads to use. Defaults to 1.
         num_clients: The number of baton clients to use, Defaults to 1.
         print_repair: Print the paths of objects that required repair and were

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,17 @@ from ml_warehouse.schema import (
 )
 
 from partisan import icommands
-from partisan.icommands import imkdir, iput, irm, mkgroup, rmgroup
+from partisan.icommands import (
+    add_specific_sql,
+    have_admin,
+    imkdir,
+    iput,
+    iquest,
+    irm,
+    mkgroup,
+    remove_specific_sql,
+    rmgroup,
+)
 from partisan.irods import (
     AC,
     AVU,
@@ -69,13 +79,89 @@ structlog.configure(
 )
 
 
-@pytest.fixture(scope="session")
-def config() -> configparser.ConfigParser:
-    # Database credentials for the test MySQL instance are stored here. This
-    # should be an instance in a container, discarded after each test run.
-    test_config = configparser.ConfigParser()
-    test_config.read(test_ini)
-    yield test_config
+tests_have_admin = pytest.mark.skipif(
+    not have_admin(), reason="tests do not have iRODS admin access"
+)
+
+TEST_GROUPS = ["ss_study_01", "ss_study_02", "ss_study_03"]
+
+TEST_SQL_STALE_REPLICATE = "setObjectReplStale"
+TEST_SQL_INVALID_CHECKSUM = "setObjectChecksumInvalid"
+
+NUM_SIMPLE_EXPTS = 5
+NUM_MULTIPLEXED_EXPTS = 3
+NUM_INSTRUMENT_SLOTS = 5
+
+BEGIN = datetime(year=2020, month=1, day=1, hour=0, minute=0, second=0)
+EARLY = datetime(year=2020, month=6, day=1, hour=0, minute=0, second=0)
+LATE = datetime(year=2020, month=6, day=14, hour=0, minute=0, second=0)
+LATEST = datetime(year=2020, month=6, day=30, hour=0, minute=0, second=0)
+
+
+def add_test_groups():
+    if have_admin():
+        for g in TEST_GROUPS:
+            mkgroup(g)
+
+
+def remove_test_groups():
+    if have_admin():
+        for g in TEST_GROUPS:
+            rmgroup(g)
+
+
+def add_sql_test_utilities():
+    if have_admin():
+        add_specific_sql(
+            TEST_SQL_STALE_REPLICATE,
+            "UPDATE r_data_main dm SET DATA_IS_DIRTY = 0 FROM r_coll_main cm "
+            "WHERE dm.coll_id = cm.coll_id "
+            "AND cm.COLL_NAME = ? "
+            "AND dm.DATA_NAME= ? "
+            "AND dm.DATA_REPL_NUM= ?",
+        )
+        add_specific_sql(
+            TEST_SQL_INVALID_CHECKSUM,
+            "UPDATE r_data_main dm SET DATA_CHECKSUM = 0 FROM r_coll_main cm "
+            "WHERE dm.coll_id = cm.coll_id "
+            "AND cm.COLL_NAME = ? "
+            "AND dm.DATA_NAME= ? "
+            "AND dm.DATA_REPL_NUM= ?",
+        )
+
+
+def remove_sql_test_utilities():
+    if have_admin():
+        remove_specific_sql(TEST_SQL_STALE_REPLICATE)
+        remove_specific_sql(TEST_SQL_INVALID_CHECKSUM)
+
+
+def add_rods_path(root_path: PurePath, tmp_path: PurePath) -> PurePath:
+    parts = PurePath(*tmp_path.parts[1:])
+    rods_path = root_path / parts
+    imkdir(rods_path, make_parents=True)
+
+    return rods_path
+
+
+def set_replicate_invalid(obj: DataObject, replicate_num: int):
+    iquest(
+        "--sql",
+        TEST_SQL_STALE_REPLICATE,
+        obj.path.as_posix(),
+        obj.name,
+        str(replicate_num),
+    )
+
+
+def set_checksum_invalid(obj: DataObject, replicate_num: int):
+    iquest(
+        "--sql",
+        TEST_SQL_INVALID_CHECKSUM,
+        obj.path.as_posix(),
+        obj.name,
+        str(replicate_num),
+    )
 
 
 def mysql_url(config: configparser.ConfigParser):
@@ -109,331 +195,6 @@ def mysql_url(config: configparser.ConfigParser):
         f"mysql+pymysql://{user}:{password}@"
         f"{ip_address}:{port}/{schema}?charset=utf8mb4"
     )
-
-
-@pytest.fixture(scope="function")
-def mlwh_session(config: configparser.ConfigParser) -> Session:
-    uri = mysql_url(config)
-    engine = create_engine(uri, echo=False, future=True)
-
-    if not database_exists(engine.url):
-        create_database(engine.url)
-
-    with engine.connect() as conn:
-        # Workaround for invalid default values for dates.
-        conn.execute(text("SET sql_mode = '';"))
-        conn.commit()
-
-    Base.metadata.create_all(engine)
-    session_maker = sessionmaker(bind=engine)
-    sess: Session() = session_maker()
-
-    initialize_mlwh_ont(sess)
-    initialize_mlwh_illumina(sess)
-
-    try:
-        yield sess
-    finally:
-        sess.close()
-
-    # This is for the benefit of MySQL where we have a schema reused for
-    # a number of tests. Without using sqlalchemy-utils, one would call:
-    #
-    #   for t in reversed(meta.sorted_tables):
-    #       t.drop(engine)
-    #
-    # Dropping the database for SQLite deletes the SQLite file.
-    drop_database(engine.url)
-
-
-icommands_have_admin = pytest.mark.skipif(
-    not icommands.have_admin(), reason="tests do not have iRODS admin access"
-)
-
-NUM_SIMPLE_EXPTS = 5
-NUM_MULTIPLEXED_EXPTS = 3
-NUM_INSTRUMENT_SLOTS = 5
-
-TEST_GROUPS = ["ss_study_01", "ss_study_02", "ss_study_03"]
-
-
-def add_test_groups():
-    if icommands.have_admin():
-        for g in TEST_GROUPS:
-            mkgroup(g)
-
-
-def remove_test_groups():
-    if icommands.have_admin():
-        for g in TEST_GROUPS:
-            rmgroup(g)
-
-
-def add_rods_path(root_path: PurePath, tmp_path: PurePath) -> PurePath:
-    parts = PurePath(*tmp_path.parts[1:])
-    rods_path = root_path / parts
-    imkdir(rods_path, make_parents=True)
-
-    return rods_path
-
-
-@pytest.fixture(scope="function")
-def simple_collection(tmp_path):
-    """A fixture providing an empty collection"""
-    root_path = PurePath("/testZone/home/irods/test/simple_collection")
-    coll_path = add_rods_path(root_path, tmp_path)
-
-    try:
-        yield coll_path
-    finally:
-        irm(root_path, force=True, recurse=True)
-
-
-@pytest.fixture(scope="function")
-def simple_data_object(tmp_path):
-    """A fixture providing a collection containing a single data object containing
-    UTF-8 data."""
-    root_path = PurePath("/testZone/home/irods/test/simple_data_object")
-    rods_path = add_rods_path(root_path, tmp_path)
-
-    obj_path = rods_path / "lorem.txt"
-    iput("./tests/data/simple/data_object/lorem.txt", obj_path)
-
-    try:
-        yield obj_path
-    finally:
-        irm(root_path, force=True, recurse=True)
-
-
-@pytest.fixture(scope="function")
-def annotated_data_object(tmp_path):
-    """A fixture providing a collection containing a single, annotated data object
-    containing UTF-8 data."""
-
-    root_path = PurePath("/testZone/home/irods/test/annotated_data_object")
-    rods_path = add_rods_path(root_path, tmp_path)
-
-    obj_path = rods_path / "lorem.txt"
-    iput("./tests/data/simple/data_object/lorem.txt", obj_path)
-
-    obj = DataObject(obj_path)
-    obj.add_metadata(
-        AVU(DublinCore.CREATED, datetime.utcnow().isoformat(timespec="seconds")),
-        AVU(DublinCore.CREATOR, "dummy creator"),
-        AVU(DublinCore.PUBLISHER, "dummy publisher"),
-        AVU(DataFile.TYPE, "txt"),
-        AVU(DataFile.MD5, "39a4aa291ca849d601e4e5b8ed627a04"),
-    )
-
-    try:
-        yield obj_path
-    finally:
-        irm(root_path, force=True, recurse=True)
-
-
-@pytest.fixture(scope="function")
-def annotated_tree(tmp_path):
-    """A fixture providing a tree of collections and data objects, with both
-    collections and data objects having annotation."""
-
-    root_path = PurePath("/testZone/home/irods/test/annotated_tree")
-    rods_path = add_rods_path(root_path, tmp_path)
-
-    iput("./tests/data/tree", rods_path, recurse=True)
-    tree_root = rods_path / "tree"
-
-    add_test_groups()
-    ac = AC("ss_study_01", Permission.READ, zone="testZone")
-
-    coll = Collection(tree_root)
-
-    # Create some empty collections
-    c = Collection(coll.path / "c")
-    c.create()
-    for x in ["s", "t", "u"]:
-        Collection(c.path / x).create()
-
-    coll.add_metadata(AVU("path", str(coll)))
-    coll.add_permissions(ac)
-
-    for item in coll.contents(recurse=True):
-        item.add_metadata(AVU("path", str(item)))
-        item.add_permissions(ac)
-
-    try:
-        yield tree_root
-    finally:
-        irm(root_path, force=True, recurse=True)
-        remove_test_groups()
-
-
-@pytest.fixture(scope="function")
-def special_paths(tmp_path):
-    """A fixture providing a collection of challengingly named paths which contain spaces
-    and/or quotes."""
-    root_path = PurePath("/testZone/home/irods/test")
-    rods_path = add_rods_path(root_path, tmp_path)
-
-    iput("./tests/data/special", rods_path, recurse=True)
-    expt_root = rods_path / "special"
-
-    try:
-        yield expt_root
-    finally:
-        irm(root_path, force=True, recurse=True)
-
-
-@pytest.fixture(scope="function")
-def ont_gridion(tmp_path):
-    """A fixture providing a set of files based on output from an ONT GridION
-    instrument. This dataset provides an example of file and directory naming
-    conventions. The file contents are dummy values."""
-    root_path = PurePath("/testZone/home/irods/test/ont_gridion")
-    rods_path = add_rods_path(root_path, tmp_path)
-
-    iput("./tests/data/ont/gridion", rods_path, recurse=True)
-    expt_root = rods_path / "gridion"
-    add_test_groups()
-
-    try:
-        yield expt_root
-    finally:
-        irm(root_path, force=True, recurse=True)
-        remove_test_groups()
-
-
-@pytest.fixture(scope="function")
-def ont_synthetic(tmp_path):
-    """A fixture providing a synthetic set of files and metadata based on output
-    from an ONT GridION instrument, modified to represent the way simple and
-    multiplexed experiments are laid out. The file contents are dummy values."""
-    root_path = PurePath("/testZone/home/irods/test/ont_synthetic")
-    rods_path = add_rods_path(root_path, tmp_path)
-
-    expt_root = PurePath(rods_path, "synthetic")
-    add_test_groups()
-
-    for expt in range(1, NUM_SIMPLE_EXPTS + 1):
-        for slot in range(1, NUM_INSTRUMENT_SLOTS + 1):
-            expt_name = f"simple_experiment_{expt :0>3}"
-            id_flowcell = f"flowcell{slot + 10 :0>3}"
-            run_folder = f"20190904_1514_G{slot}00000_{id_flowcell}_69126024"
-
-            coll = Collection(expt_root / expt_name / run_folder)
-            coll.create(parents=True)
-            meta = [
-                avu.with_namespace(Instrument.namespace)
-                for avu in [
-                    AVU(Instrument.EXPERIMENT_NAME, expt_name),
-                    AVU(Instrument.INSTRUMENT_SLOT, f"{slot}"),
-                ]
-            ]
-            coll.add_metadata(*meta)
-
-    for expt in range(1, NUM_MULTIPLEXED_EXPTS + 1):
-        for slot in range(1, NUM_INSTRUMENT_SLOTS + 1):
-            expt_name = f"multiplexed_experiment_{expt :0>3}"
-            id_flowcell = f"flowcell{slot + 100 :0>3}"
-            run_folder = f"20190904_1514_GA{slot}0000_{id_flowcell}_cf751ba1"
-
-            coll = Collection(expt_root / expt_name / run_folder)
-            coll.create(parents=True)
-            meta = [
-                avu.with_namespace(Instrument.namespace)
-                for avu in [
-                    AVU(Instrument.EXPERIMENT_NAME, expt_name),
-                    AVU(Instrument.INSTRUMENT_SLOT, f"{slot}"),
-                ]
-            ]
-            coll.add_metadata(*meta)
-
-    # We have synthetic data only for simple_experiment_001 and
-    # multiplexed_experiment_001
-    iput("./tests/data/ont/synthetic", rods_path, recurse=True)
-
-    try:
-        yield expt_root
-    finally:
-        irm(root_path, force=True, recurse=True)
-        remove_test_groups()
-
-
-@pytest.fixture(scope="function")
-def illumina_products(tmp_path):
-    root_path = PurePath("/testZone/home/irods/test/illumina_products")
-    rods_path = add_rods_path(root_path, tmp_path)
-
-    Collection(rods_path).create(parents=True)
-
-    metadata = {
-        "12345/12345#1.cram": (
-            AVU("id_product", "31a3d460bb3c7d98845187c716a30db81c44b615"),
-            AVU("component", "{'id_run': 12345, 'position': 1, 'tag_index': 1}"),
-            AVU("component", "{'id_run': 12345, 'position': 2, 'tag_index': 1}"),
-            AVU("reference", "Any/other/reference"),
-            AVU("tag_index", 1),
-        ),
-        "12345/12345#2.cram": (
-            AVU("id_product", "0b3bd00f1d186247f381aa87e213940b8c7ab7e5"),
-            AVU("component", "{'id_run': 12345, 'position': 1, 'tag_index': 2"),
-            AVU("component", "{'id_run': 12345, 'position': 2, 'tag_index': 2"),
-            AVU("tag_index", 2),
-            AVU("alt_process", "Alternative Process"),
-        ),
-        "12345/12345#1_phix.cram": (
-            AVU("id_product", "31a3d460bb3c7d98845187c716a30db81c44b615"),
-            AVU(
-                "component",
-                "{'id_run': 12345, 'position': 1, 'subset': 'phix', tag_index': 1}",
-            ),
-            AVU(
-                "component",
-                "{'id_run': 12345, 'position': 2, 'subset': 'phix', tag_index': 1}",
-            ),
-            AVU("tag_index", 1),
-        ),
-        "12345/12345#888.cram": (
-            AVU("id_product", "5e67fc5c63b7ceb4e63bbb8e62ab58dcc57b6e64"),
-            AVU("component", "{'id_run': 12345, 'position': 1, 'tag_index': 888"),
-            AVU("component", "{'id_run': 12345, 'position': 2, 'tag_index': 888"),
-            AVU("reference", "A/reference/with/PhiX/present"),
-            AVU("tag_index", 888),
-        ),
-        "12345/12345#0.cram": (
-            AVU("id_product", "f54f4a5c3eba5bdf302c1ce4a7c18add33a04315"),
-            AVU("component", "{'id_run': 12345, 'position': 1, 'tag_index': 0"),
-            AVU("component", "{'id_run': 12345, 'position': 2, 'tag_index': 0"),
-            AVU("tag_index", 0),
-        ),
-        "12345/cellranger/12345.cram": (),
-        "54321/54321#1.bam": (
-            AVU("id_product", "1a08a7027d9f9c20d01909989370ea6b70a5bccc"),
-            AVU("component", "{'id_run': 54321, 'position': 1, 'tag_index': 1}"),
-            AVU("component", "{'id_run': 54321, 'position': 2, 'tag_index': 1}"),
-            AVU("tag_index", 1),
-        ),
-        "67890/67890#1.cram": (
-            AVU("component", "{'id_run': 54321, 'position': 1, 'tag_index': 1}"),
-            AVU("component", "{'id_run': 54321, 'position': 2, 'tag_index': 1}"),
-            AVU("tag_index", 1),
-        ),
-    }
-
-    iput("./tests/data/illumina/mlwh_locations", rods_path, recurse=True)
-    for path in metadata.keys():
-        obj = DataObject(rods_path / "mlwh_locations" / path)
-        for avu in metadata[path]:
-            obj.add_metadata(avu)
-    try:
-        yield rods_path / "mlwh_locations"
-    finally:
-        irm(root_path, force=True, recurse=True)
-
-
-BEGIN = datetime(year=2020, month=1, day=1, hour=0, minute=0, second=0)
-EARLY = datetime(year=2020, month=6, day=1, hour=0, minute=0, second=0)
-LATE = datetime(year=2020, month=6, day=14, hour=0, minute=0, second=0)
-LATEST = datetime(year=2020, month=6, day=30, hour=0, minute=0, second=0)
 
 
 def initialize_mlwh_ont(session: Session):
@@ -754,3 +515,325 @@ def initialize_mlwh_illumina(sess: Session):
         ]
     )
     sess.commit()
+
+
+@pytest.fixture(scope="session")
+def sql_test_utilities():
+    try:
+        add_sql_test_utilities()
+        yield
+    finally:
+        remove_sql_test_utilities()
+
+
+@pytest.fixture(scope="session")
+def config() -> configparser.ConfigParser:
+    # Database credentials for the test MySQL instance are stored here. This
+    # should be an instance in a container, discarded after each test run.
+    test_config = configparser.ConfigParser()
+    test_config.read(test_ini)
+    yield test_config
+
+
+@pytest.fixture(scope="function")
+def mlwh_session(config: configparser.ConfigParser) -> Session:
+    uri = mysql_url(config)
+    engine = create_engine(uri, echo=False, future=True)
+
+    if not database_exists(engine.url):
+        create_database(engine.url)
+
+    with engine.connect() as conn:
+        # Workaround for invalid default values for dates.
+        conn.execute(text("SET sql_mode = '';"))
+        conn.commit()
+
+    Base.metadata.create_all(engine)
+    session_maker = sessionmaker(bind=engine)
+    sess: Session() = session_maker()
+
+    initialize_mlwh_ont(sess)
+    initialize_mlwh_illumina(sess)
+
+    try:
+        yield sess
+    finally:
+        sess.close()
+
+    # This is for the benefit of MySQL where we have a schema reused for
+    # a number of tests. Without using sqlalchemy-utils, one would call:
+    #
+    #   for t in reversed(meta.sorted_tables):
+    #       t.drop(engine)
+    #
+    # Dropping the database for SQLite deletes the SQLite file.
+    drop_database(engine.url)
+
+
+@pytest.fixture(scope="function")
+def simple_collection(tmp_path):
+    """A fixture providing an empty collection"""
+    root_path = PurePath("/testZone/home/irods/test/simple_collection")
+    coll_path = add_rods_path(root_path, tmp_path)
+
+    try:
+        yield coll_path
+    finally:
+        irm(root_path, force=True, recurse=True)
+
+
+@pytest.fixture(scope="function")
+def simple_data_object(tmp_path):
+    """A fixture providing a collection containing a single data object containing
+    UTF-8 data."""
+    root_path = PurePath("/testZone/home/irods/test/simple_data_object")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    obj_path = rods_path / "lorem.txt"
+    iput("./tests/data/simple/data_object/lorem.txt", obj_path)
+
+    try:
+        yield obj_path
+    finally:
+        irm(root_path, force=True, recurse=True)
+
+
+@pytest.fixture(scope="function")
+def annotated_data_object(tmp_path):
+    """A fixture providing a collection containing a single, annotated data object
+    containing UTF-8 data."""
+
+    root_path = PurePath("/testZone/home/irods/test/annotated_data_object")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    obj_path = rods_path / "lorem.txt"
+    iput("./tests/data/simple/data_object/lorem.txt", obj_path)
+
+    obj = DataObject(obj_path)
+    obj.add_metadata(
+        AVU(DublinCore.CREATED, datetime.utcnow().isoformat(timespec="seconds")),
+        AVU(DublinCore.CREATOR, "dummy creator"),
+        AVU(DublinCore.PUBLISHER, "dummy publisher"),
+        AVU(DataFile.TYPE, "txt"),
+        AVU(DataFile.MD5, "39a4aa291ca849d601e4e5b8ed627a04"),
+    )
+
+    try:
+        yield obj_path
+    finally:
+        irm(root_path, force=True, recurse=True)
+
+
+@pytest.fixture(scope="function")
+def invalid_replica_data_object(tmp_path, sql_test_utilities):
+    """A fixture providing a data object with one of its two replicas marked invalid."""
+    root_path = PurePath("/testZone/home/irods/test")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    obj_path = rods_path / "invalid_replica.txt"
+    iput("./tests/data/simple/data_object/lorem.txt", obj_path)
+    set_replicate_invalid(DataObject(obj_path), 1)
+
+    try:
+        yield obj_path
+    finally:
+        irm(root_path, force=True, recurse=True)
+
+
+@pytest.fixture(scope="function")
+def annotated_tree(tmp_path):
+    """A fixture providing a tree of collections and data objects, with both
+    collections and data objects having annotation."""
+
+    root_path = PurePath("/testZone/home/irods/test/annotated_tree")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    iput("./tests/data/tree", rods_path, recurse=True)
+    tree_root = rods_path / "tree"
+
+    add_test_groups()
+    ac = AC("ss_study_01", Permission.READ, zone="testZone")
+
+    coll = Collection(tree_root)
+
+    # Create some empty collections
+    c = Collection(coll.path / "c")
+    c.create()
+    for x in ["s", "t", "u"]:
+        Collection(c.path / x).create()
+
+    coll.add_metadata(AVU("path", str(coll)))
+    coll.add_permissions(ac)
+
+    for item in coll.contents(recurse=True):
+        item.add_metadata(AVU("path", str(item)))
+        item.add_permissions(ac)
+
+    try:
+        yield tree_root
+    finally:
+        irm(root_path, force=True, recurse=True)
+        remove_test_groups()
+
+
+@pytest.fixture(scope="function")
+def special_paths(tmp_path):
+    """A fixture providing a collection of challengingly named paths which contain spaces
+    and/or quotes."""
+    root_path = PurePath("/testZone/home/irods/test")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    iput("./tests/data/special", rods_path, recurse=True)
+    expt_root = rods_path / "special"
+
+    try:
+        yield expt_root
+    finally:
+        irm(root_path, force=True, recurse=True)
+
+
+@pytest.fixture(scope="function")
+def ont_gridion(tmp_path):
+    """A fixture providing a set of files based on output from an ONT GridION
+    instrument. This dataset provides an example of file and directory naming
+    conventions. The file contents are dummy values."""
+    root_path = PurePath("/testZone/home/irods/test/ont_gridion")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    iput("./tests/data/ont/gridion", rods_path, recurse=True)
+    expt_root = rods_path / "gridion"
+    add_test_groups()
+
+    try:
+        yield expt_root
+    finally:
+        irm(root_path, force=True, recurse=True)
+        remove_test_groups()
+
+
+@pytest.fixture(scope="function")
+def ont_synthetic(tmp_path):
+    """A fixture providing a synthetic set of files and metadata based on output
+    from an ONT GridION instrument, modified to represent the way simple and
+    multiplexed experiments are laid out. The file contents are dummy values."""
+    root_path = PurePath("/testZone/home/irods/test/ont_synthetic")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    expt_root = PurePath(rods_path, "synthetic")
+    add_test_groups()
+
+    for expt in range(1, NUM_SIMPLE_EXPTS + 1):
+        for slot in range(1, NUM_INSTRUMENT_SLOTS + 1):
+            expt_name = f"simple_experiment_{expt :0>3}"
+            id_flowcell = f"flowcell{slot + 10 :0>3}"
+            run_folder = f"20190904_1514_G{slot}00000_{id_flowcell}_69126024"
+
+            coll = Collection(expt_root / expt_name / run_folder)
+            coll.create(parents=True)
+            meta = [
+                avu.with_namespace(Instrument.namespace)
+                for avu in [
+                    AVU(Instrument.EXPERIMENT_NAME, expt_name),
+                    AVU(Instrument.INSTRUMENT_SLOT, f"{slot}"),
+                ]
+            ]
+            coll.add_metadata(*meta)
+
+    for expt in range(1, NUM_MULTIPLEXED_EXPTS + 1):
+        for slot in range(1, NUM_INSTRUMENT_SLOTS + 1):
+            expt_name = f"multiplexed_experiment_{expt :0>3}"
+            id_flowcell = f"flowcell{slot + 100 :0>3}"
+            run_folder = f"20190904_1514_GA{slot}0000_{id_flowcell}_cf751ba1"
+
+            coll = Collection(expt_root / expt_name / run_folder)
+            coll.create(parents=True)
+            meta = [
+                avu.with_namespace(Instrument.namespace)
+                for avu in [
+                    AVU(Instrument.EXPERIMENT_NAME, expt_name),
+                    AVU(Instrument.INSTRUMENT_SLOT, f"{slot}"),
+                ]
+            ]
+            coll.add_metadata(*meta)
+
+    # We have synthetic data only for simple_experiment_001 and
+    # multiplexed_experiment_001
+    iput("./tests/data/ont/synthetic", rods_path, recurse=True)
+
+    try:
+        yield expt_root
+    finally:
+        irm(root_path, force=True, recurse=True)
+        remove_test_groups()
+
+
+@pytest.fixture(scope="function")
+def illumina_products(tmp_path):
+    root_path = PurePath("/testZone/home/irods/test/illumina_products")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    Collection(rods_path).create(parents=True)
+
+    metadata = {
+        "12345/12345#1.cram": (
+            AVU("id_product", "31a3d460bb3c7d98845187c716a30db81c44b615"),
+            AVU("component", "{'id_run': 12345, 'position': 1, 'tag_index': 1}"),
+            AVU("component", "{'id_run': 12345, 'position': 2, 'tag_index': 1}"),
+            AVU("reference", "Any/other/reference"),
+            AVU("tag_index", 1),
+        ),
+        "12345/12345#2.cram": (
+            AVU("id_product", "0b3bd00f1d186247f381aa87e213940b8c7ab7e5"),
+            AVU("component", "{'id_run': 12345, 'position': 1, 'tag_index': 2"),
+            AVU("component", "{'id_run': 12345, 'position': 2, 'tag_index': 2"),
+            AVU("tag_index", 2),
+            AVU("alt_process", "Alternative Process"),
+        ),
+        "12345/12345#1_phix.cram": (
+            AVU("id_product", "31a3d460bb3c7d98845187c716a30db81c44b615"),
+            AVU(
+                "component",
+                "{'id_run': 12345, 'position': 1, 'subset': 'phix', tag_index': 1}",
+            ),
+            AVU(
+                "component",
+                "{'id_run': 12345, 'position': 2, 'subset': 'phix', tag_index': 1}",
+            ),
+            AVU("tag_index", 1),
+        ),
+        "12345/12345#888.cram": (
+            AVU("id_product", "5e67fc5c63b7ceb4e63bbb8e62ab58dcc57b6e64"),
+            AVU("component", "{'id_run': 12345, 'position': 1, 'tag_index': 888"),
+            AVU("component", "{'id_run': 12345, 'position': 2, 'tag_index': 888"),
+            AVU("reference", "A/reference/with/PhiX/present"),
+            AVU("tag_index", 888),
+        ),
+        "12345/12345#0.cram": (
+            AVU("id_product", "f54f4a5c3eba5bdf302c1ce4a7c18add33a04315"),
+            AVU("component", "{'id_run': 12345, 'position': 1, 'tag_index': 0"),
+            AVU("component", "{'id_run': 12345, 'position': 2, 'tag_index': 0"),
+            AVU("tag_index", 0),
+        ),
+        "12345/cellranger/12345.cram": (),
+        "54321/54321#1.bam": (
+            AVU("id_product", "1a08a7027d9f9c20d01909989370ea6b70a5bccc"),
+            AVU("component", "{'id_run': 54321, 'position': 1, 'tag_index': 1}"),
+            AVU("component", "{'id_run': 54321, 'position': 2, 'tag_index': 1}"),
+            AVU("tag_index", 1),
+        ),
+        "67890/67890#1.cram": (
+            AVU("component", "{'id_run': 54321, 'position': 1, 'tag_index': 1}"),
+            AVU("component", "{'id_run': 54321, 'position': 2, 'tag_index': 1}"),
+            AVU("tag_index", 1),
+        ),
+    }
+
+    iput("./tests/data/illumina/mlwh_locations", rods_path, recurse=True)
+    for path in metadata.keys():
+        obj = DataObject(rods_path / "mlwh_locations" / path)
+        for avu in metadata[path]:
+            obj.add_metadata(avu)
+    try:
+        yield rods_path / "mlwh_locations"
+    finally:
+        irm(root_path, force=True, recurse=True)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -25,7 +25,7 @@ import pytest
 from partisan.irods import AVU, DataObject, Replica
 from pytest import mark as m
 
-from conftest import icommands_have_admin
+from conftest import tests_have_admin
 from npg_irods.exception import ChecksumError
 from npg_irods.metadata.common import (
     CompressSuffix,
@@ -345,7 +345,7 @@ class TestCreationMetadata:
 
 @m.describe("Common metadata")
 class TestCommonMetadata:
-    @icommands_have_admin
+    @tests_have_admin
     @m.context("When common metadata are present")
     @m.context("A has_ function is called")
     @m.it("Returns True")

--- a/tests/test_ont.py
+++ b/tests/test_ont.py
@@ -21,13 +21,13 @@ from partisan.irods import AC, AVU, Collection, Permission
 from pytest import mark as m
 
 from npg_irods import ont
-from conftest import LATEST, icommands_have_admin
+from conftest import LATEST, tests_have_admin
 from npg_irods.metadata.lims import SeqConcept, TrackedSample, TrackedStudy
 from npg_irods.ont import MetadataUpdate, annotate_results_collection
 
 
 class TestONT(object):
-    @icommands_have_admin
+    @tests_have_admin
     @m.context("When an ONT experiment collection is annotated")
     @m.context("When the experiment is single-sample")
     @m.it("Adds sample and study metadata to the run-folder collection")
@@ -53,7 +53,7 @@ class TestONT(object):
         for item in coll.contents():
             assert ac in item.acl(), f"{ac} is in {item} ACL"
 
-    @icommands_have_admin
+    @tests_have_admin
     @m.context("When the experiment is multiplexed")
     @m.it("Adds {tag_index_from_id => <n>} metadata to barcode<0n> sub-collections")
     def test_add_new_plex_metadata(self, ont_synthetic, mlwh_session):
@@ -72,7 +72,7 @@ class TestONT(object):
             avu = AVU(SeqConcept.TAG_INDEX, ont.tag_index_from_id(tag_identifier))
             assert avu in bc_coll.metadata(), f"{avu} is in {bc_coll} metadata"
 
-    @icommands_have_admin
+    @tests_have_admin
     @m.it("Adds sample and study metadata to barcode<0n> sub-collections")
     def test_add_new_plex_sample_metadata(self, ont_synthetic, mlwh_session):
         expt = "multiplexed_experiment_001"
@@ -103,7 +103,7 @@ class TestONT(object):
 
 
 class TestMetadataUpdate(object):
-    @icommands_have_admin
+    @tests_have_admin
     @m.context("When an ONT metadata update is requested")
     @m.context("When no experiment name is specified")
     @m.context("When no time window is specified")


### PR DESCRIPTION
Add check-replicas script.
Add repair-replicas script.
Add support API for handling replicas (requires new API features in partisan to be in version 2.1.0).
Reorganise some test fixtures and helper functions to be more consistent with partisan.

Requires https://github.com/wtsi-npg/partisan/pull/79 and release of partisan 2.1.0