### PR TITLE
Update iRODS clients container to one using the RENCI clients/libs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   irods-clients:
     container_name: irods-clients
-    image: "wsinpg/md-bullseye-irods-clients-${IRODS_VERSION:-4.2.11}:${DOCKER_TAG:-latest}"
+    image: "wsinpg/ub-18.04-irods-clients-${IRODS_VERSION:-4.2.11}:${DOCKER_TAG:-latest}"
     volumes:
       - "${PWD}:${PWD}"
       - "${PWD}/tests/.irods:${HOME}/.irods/"


### PR DESCRIPTION
The previous image used packages built with Conda. This uses the official RENCI Debian packages.