### PR TITLE
Add Dockerfile to build an application image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.DS_Store
+.dockerignore
+.github
+.gitignore
+.pytest_cache
+Dockerfile
+dist
+LICENSE
+README.md
+docker-compose.yml
+pytest.ini
+*.report.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+# syntax = docker/dockerfile:1.2
+
+FROM ubuntu:bionic as builder
+
+ARG PYTHON_VERSION=3.10
+
+RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libtool \
+    pkg-config \
+    libbz2-dev \
+    libssl-dev \
+    zlib1g-dev \
+    unattended-upgrades && \
+    unattended-upgrade -d -v
+
+WORKDIR /app
+
+COPY . .
+
+ENV PYENV_ROOT "/app/.pyenv"
+ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+
+RUN ./docker/install_pyenv.sh
+
+RUN pyenv install "$PYTHON_VERSION"
+RUN pyenv global "$PYTHON_VERSION"
+
+# This drives the choice of base system for this Dockerfile. iRODS 4.2.11 is not
+# available for anything more recent than Ubuntu bionic, so that's what we use for
+# the builder (above) and for the clients. This is also the reason we resort to
+# pyenv to get a recent Python, rather than using a python-slim base image.
+FROM wsinpg/ub-18.04-irods-clients-4.2.11
+
+RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    ca-certificates \
+    git \
+    unattended-upgrades && \
+    unattended-upgrade -d -v
+
+ENV PYENV_ROOT "/app/.pyenv"
+ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /app
+
+COPY --from=builder /app /app
+
+# Mount the .git directory to allow setuptools_scm to get the version
+RUN --mount=source=.git,target=.git,type=bind \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir .
+
+RUN useradd -l -m -s /bin/false appuser && mkdir /home/appuser/.irods
+
+RUN apt-get remove -q -y unattended-upgrades \
+    git && \
+    apt-get autoremove -q -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+USER appuser
+
+ENTRYPOINT ["/app/docker/docker-entrypoint.sh"]
+
+CMD ["check-checksums", "--version"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+export PYENV_ROOT="/app/.pyenv"
+export PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+export PYTHONUNBUFFERED=1
+
+exec "$@"

--- a/docker/install_pyenv.sh
+++ b/docker/install_pyenv.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+PYENV_RELEASE_VERSION=${PYENV_RELEASE_VERSION:="2.3.13"}
+export PYENV_GIT_TAG="v${PYENV_RELEASE_VERSION}"
+
+PYENV_ROOT=${PYENV_ROOT:-"$HOME/.pyenv"}
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+curl -sSL -O https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer
+/bin/bash ./pyenv-installer


### PR DESCRIPTION
The image incorporates the necessary iRODS clients (hence the large size). It is based on Ubuntu bionic because that is a requirement for iRODS support, but installs a more recent Python.