### PR TITLE
Update ml-warehouse and partisan dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/wtsi-npg/ml-warehouse-python.git@1.0.0#egg=ml-warehouse
+ml-warehouse@https://github.com/wtsi-npg/ml-warehouse-python/releases/download/1.1.0/ml-warehouse-1.1.0.tar.gz
 partisan@https://github.com/wtsi-npg/partisan/releases/download/2.1.0/partisan-2.1.0.tar.gz
 rich==13.3.1
 setuptools==67.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ setup(
     author="Keith James",
     author_email="kdj@sanger.ac.uk",
     description=".",
-    use_scm_version=True,
+    use_scm_version={"version_scheme": "no-guess-dev"},
     python_requires=">=3.10",
     packages=find_packages("src"),
     package_dir={"": "src"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2020, 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2020, 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,7 +42,6 @@ from ml_warehouse.schema import (
     Study,
 )
 
-from partisan import icommands
 from partisan.icommands import (
     add_specific_sql,
     have_admin,


### PR DESCRIPTION
Update ml-warehouse to us the built package.
Update partisan from 2.0 to 2.1.

Configure setuptools_scm to avoid generating legacy version strings from git (which setuptools now rejects).