### PR TITLE
Improvements to initial ONT metadata update script

### DIFF
--- a/scripts/update-ont-metadata
+++ b/scripts/update-ont-metadata
@@ -31,19 +31,26 @@ import sqlalchemy
 from sqlalchemy.orm import Session
 
 description = """
-This script updates the ONT metadata of a file set. The idea is to update
-the metadata of files that were generated within a user-specified
-date window.
+Updates metadata and data access permissions on ONT run collections in iRODS, to reflect
+information in the Multi-LIMS warehouse.
+
+The metadata updated are "secondary" i.e. sample- and study-related information which
+may be subject to change when tracking information in the ML warehouse is updated e.g.
+to correct an error. 
+
+Only runs whose ML warehouse records have been updated recently are updated. The default
+window for detecting changes is the 14 days prior to the time when the script is run.
+This can be changed using the --begin-date CLI option.
 """
 
 
-def my_date_parser(date: str) -> datetime:
-    """Custom argparse type for user date"""
+def parse_iso_date(date: str) -> datetime:
+    """Custom argparse type for ISO8601 dates."""
     try:
         return dateutil.parser.isoparse(date)
     except ValueError:
         raise argparse.ArgumentTypeError(
-            f"Wrong format {date}. It must be in ISO format 8601."
+            f"Incorrect format {date}. Please use ISO8601 UTC e.g. 2022-01-30T11:11:03Z"
         )
 
 
@@ -52,23 +59,25 @@ parser = argparse.ArgumentParser(
 )
 
 parser.add_argument(
-    "--begin_date",
     "--begin-date",
-    help="Range initial date from when you want to look for runs. Default to 14 days back.",
-    type=my_date_parser,
+    "--begin_date",
+    help="Limit runs found to those changed after this date. Defaults to 14 days ago. "
+    "The argument must be an ISO8601 UTC date or date and time e.g. 2022-01-30, "
+    "2022-01-30T11:11:03Z",
+    type=parse_iso_date,
     default=datetime.now() - timedelta(days=14),
 )
 parser.add_argument(
-    "--database_config",
     "--database-config",
+    "--database_config",
     help="Configuration file for database connection.",
     type=argparse.FileType("r"),
     required=True,
 )
 group1 = parser.add_mutually_exclusive_group()
 group1.add_argument(
-    "--log_config",
     "--log-config",
+    "--log_config",
     help="A logging configuration file.",
     type=argparse.FileType("r"),
 )
@@ -133,7 +142,7 @@ def main():
     mysql_section = dbconfig[section]
     db_user = mysql_section.get("user")
     db_pwd = mysql_section.get("password")
-    db_host = mysql_section.get("ip_address")
+    db_host = mysql_section.get("host")
     db_port = mysql_section.get("port")
     db_name = mysql_section.get("schema")
 
@@ -142,11 +151,25 @@ def main():
     engine = sqlalchemy.create_engine(connection_uri)
     with Session(engine) as session:
         mu = MetadataUpdate()
-        updated = mu.update_secondary_metadata(session, since=args.begin_date)
-        for path in updated:
-            log.info("Updated collection", path=path)
-        if not updated:
-            log.info("No collection has been updated")
+        num_processed, num_updated, num_errors = mu.update_secondary_metadata(
+            session, since=args.begin_date
+        )
+
+        if num_errors:
+            log.error(
+                "Update failed",
+                num_processed=num_processed,
+                num_updated=num_updated,
+                num_errors=num_errors,
+            )
+            exit(1)
+
+        log.info(
+            "Metadata updated",
+            num_processed=num_processed,
+            num_updated=num_updated,
+            num_errors=num_errors,
+        )
 
 
 if __name__ == "__main__":

--- a/src/npg_irods/ont.py
+++ b/src/npg_irods/ont.py
@@ -59,6 +59,10 @@ class MetadataUpdate(object):
         """Update iRODS secondary metadata on ONT run collections whose corresponding
         ML warehouse records have been updated more recently than the specified time.
 
+        Collections to update are identified by having ont:experiment_name and
+        ont:instrument_slot metadata already attached to them. This is done for example,
+        by the process which moves sequence data from the instrument into iRODS.
+
         Args:
             mlwh_session: An open SQL session.
             since: A datetime.
@@ -187,6 +191,24 @@ def annotate_results_collection(
     instrument_slot: int,
     mlwh_session: Session,
 ) -> bool:
+    """Add or update metadata on an existing iRODS collection containing ONT data.
+
+    The metadata added are fetched from the ML warehouse and include information on the
+    sample and the associated study, including data access permissions. This function
+    also sets the appropriate permissions in iRODS.
+
+    This function is idempotent. No harm will come from running it an an already
+    up-to-date collection.
+
+    Args:
+        path: A collection path to annotate.
+        experiment_name: The ONT experiment name.
+        instrument_slot: The ONT instrument slot number.
+        mlwh_session:
+
+    Returns:
+        True on success.
+    """
     log.debug(
         "Searching the warehouse for plex information",
         experiment=experiment_name,

--- a/tests/test_ont.py
+++ b/tests/test_ont.py
@@ -113,24 +113,28 @@ class TestMetadataUpdate(object):
         num_slots = 5
 
         update = MetadataUpdate()
-        updated = update.update_secondary_metadata(mlwh_session=mlwh_session)
-        expected_count = (num_simple_expts * num_slots) + (
+        num_found, num_updated, num_errors = update.update_secondary_metadata(
+            mlwh_session=mlwh_session
+        )
+        num_expected = (num_simple_expts * num_slots) + (
             num_multiplexed_expts * num_slots
         )
 
-        assert len(updated) == expected_count, f"Found {expected_count} collections"
+        assert num_found == num_expected, f"Found {num_expected} collections"
+        assert num_updated == num_expected
+        assert num_errors == 0
 
     @m.context("When no experiment name is specified")
     @m.context("When a time window is specified")
     @m.it("Finds only collections updated in that time window")
     def test_find_recent_updates(self, ont_synthetic, mlwh_session):
         update = MetadataUpdate()
-        updated = update.update_secondary_metadata(
+        num_found, num_updated, num_errors = update.update_secondary_metadata(
             mlwh_session=mlwh_session, since=LATEST
         )
 
         # Only slots 1, 3 and 5 of multiplexed experiments 1 and 3 were updated in
-        # the MLWH since time LATEST
+        # the MLWH since time LATEST i.e.
         expected_colls = [
             Collection(ont_synthetic / path)
             for path in [
@@ -142,16 +146,22 @@ class TestMetadataUpdate(object):
                 "multiplexed_experiment_003/20190904_1514_GA50000_flowcell105_cf751ba1",
             ]
         ]
+        num_expected = len(expected_colls)
 
-        assert (
-            updated == expected_colls
-        ), "Found slots 1, 3 and 5 of multiplexed experiments 1 and 3"
+        assert num_found == num_expected, (
+            f"Found {num_expected} collections "
+            "(slots 1, 3 and 5 of multiplexed experiments 1 and 3)"
+        )
+        assert num_updated == num_expected
+        assert num_errors == 0
 
     @m.context("When an experiment name is specified")
     @m.it("Finds only collections with that experiment name")
     def test_find_updates_for_experiment(self, ont_synthetic, mlwh_session):
         update = MetadataUpdate(experiment_name="simple_experiment_001")
-        updated = update.update_secondary_metadata(mlwh_session=mlwh_session)
+        num_found, num_updated, num_errors = update.update_secondary_metadata(
+            mlwh_session=mlwh_session
+        )
 
         expected_colls = [
             Collection(ont_synthetic / path)
@@ -163,7 +173,13 @@ class TestMetadataUpdate(object):
                 "simple_experiment_001/20190904_1514_G500000_flowcell015_69126024",
             ]
         ]
-        assert updated == expected_colls, "Found all slots from simple experiment 1"
+        num_expected = len(expected_colls)
+
+        assert (
+            num_found == num_expected
+        ), f"Found {num_expected} collections (all slots from simple experiment 1)"
+        assert num_updated == num_expected
+        assert num_errors == 0
 
     @m.context("When an experiment name is specified")
     @m.context("When a slot position is specified")
@@ -172,7 +188,9 @@ class TestMetadataUpdate(object):
         update = MetadataUpdate(
             experiment_name="simple_experiment_001", instrument_slot=1
         )
-        updated = update.update_secondary_metadata(mlwh_session=mlwh_session)
+        num_found, num_updated, num_errors = update.update_secondary_metadata(
+            mlwh_session=mlwh_session
+        )
 
         expected_colls = [
             Collection(
@@ -180,4 +198,10 @@ class TestMetadataUpdate(object):
                 / "simple_experiment_001/20190904_1514_G100000_flowcell011_69126024"
             )
         ]
-        assert updated == expected_colls, "Found slot 1 from simple experiment 1"
+        num_expected = len(expected_colls)
+
+        assert (
+            num_found == num_expected
+        ), f"Found {num_expected} collections (slot 1 from simple experiment 1)"
+        assert num_updated == num_expected
+        assert num_errors == 0


### PR DESCRIPTION
Change update_secondary_metadata to return the numbers of collections found, number updated and number of errors.

Add try/except in update_secondary_metadata to ensure that all candidate runs and collections are attempted.

Improved logging in update_secondary_metadata.

Change script to exit non-zero when there are errors.

Improved CLI help.

Rename "ip_address" to "host" in database configuration file.