### PR TITLE
Move from setuptools_scm to setuptools-git-versioning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ ml-warehouse@https://github.com/wtsi-npg/ml-warehouse-python/releases/download/1
 partisan@https://github.com/wtsi-npg/partisan/releases/download/2.1.0/partisan-2.1.0.tar.gz
 rich==13.3.1
 setuptools==67.5.1
-setuptools_scm==7.1.0
+setuptools-git-versioning==1.13.2
 sqlalchemy==1.4.44
 structlog==22.3.0

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,11 @@ setup(
     author="Keith James",
     author_email="kdj@sanger.ac.uk",
     description=".",
-    use_scm_version={"version_scheme": "no-guess-dev"},
     python_requires=">=3.10",
     packages=find_packages("src"),
     package_dir={"": "src"},
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools-git-versioning"],
+    setuptools_git_versioning={"enabled": True},
     install_requires=["ml-warehouse", "partisan", "rich", "sqlalchemy", "structlog"],
     tests_require=["black", "pytest", "pytest-it"],
     scripts=[


### PR DESCRIPTION
setuptools has recently deprecated legacy versioning, so we moved to configuring setuptools_scm with the no-guess-dev option. It appears that a release always adds version bump in addition to the git tag.

e.g. release 1.0.1 reports its version as
1.0.1.post1.dev0+g3859438.d20230308

while 3859438 is the commit that was tagged on master as 1.0.1, the version has a post-release suffix (and appears to have been interpreted as a dev release?).

The issue reported here appears to be the same:
https://github.com/pypa/setuptools_scm/issues/812

Trying setuptools-git-versioning instead in the hope that it is less "clever".