### PR TITLE
Refactor log configuration

### DIFF
--- a/scripts/check-checksums
+++ b/scripts/check-checksums
@@ -19,12 +19,11 @@
 # @author Keith James <kdj@sanger.ac.uk>
 
 import argparse
-import logging
 import sys
 
 import structlog
 
-from npg_irods.utilities import check_checksums
+from npg_irods.utilities import check_checksums, configure_logging
 from npg_irods.version import version
 
 description = """
@@ -95,34 +94,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-
-level = logging.ERROR
-if args.debug:
-    level = logging.DEBUG
-elif args.verbose:
-    level = logging.INFO
-
-logging.basicConfig(
-    level=level,
-    encoding="utf-8",
-)
-
-log_processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.processors.TimeStamper(fmt="iso", utc=True),
-]
-if args.json:
-    log_processors.append(structlog.processors.JSONRenderer())
-else:
-    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
-
-structlog.configure(
-    processors=log_processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
+configure_logging(args.debug, args.verbose, args.colour, args.json)
 log = structlog.get_logger("main")
 
 

--- a/scripts/check-common-metadata
+++ b/scripts/check-common-metadata
@@ -24,7 +24,7 @@ import sys
 
 import structlog
 
-from npg_irods.utilities import check_common_metadata
+from npg_irods.utilities import check_common_metadata, configure_logging
 from npg_irods.version import version
 
 description = """
@@ -98,34 +98,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-
-level = logging.ERROR
-if args.debug:
-    level = logging.DEBUG
-elif args.verbose:
-    level = logging.INFO
-
-logging.basicConfig(
-    level=level,
-    encoding="utf-8",
-)
-
-log_processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.processors.TimeStamper(fmt="iso", utc=True),
-]
-if args.json:
-    log_processors.append(structlog.processors.JSONRenderer())
-else:
-    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
-
-structlog.configure(
-    processors=log_processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
+configure_logging(args.debug, args.verbose, args.colour, args.json)
 log = structlog.get_logger("main")
 
 

--- a/scripts/check-replicas
+++ b/scripts/check-replicas
@@ -24,7 +24,7 @@ import sys
 
 import structlog
 
-from npg_irods.utilities import check_replicas
+from npg_irods.utilities import check_replicas, configure_logging
 from npg_irods.version import version
 
 description = """
@@ -102,34 +102,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-
-level = logging.ERROR
-if args.debug:
-    level = logging.DEBUG
-elif args.verbose:
-    level = logging.INFO
-
-logging.basicConfig(
-    level=level,
-    encoding="utf-8",
-)
-
-log_processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.processors.TimeStamper(fmt="iso", utc=True),
-]
-if args.json:
-    log_processors.append(structlog.processors.JSONRenderer())
-else:
-    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
-
-structlog.configure(
-    processors=log_processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
+configure_logging(args.debug, args.verbose, args.colour, args.json)
 log = structlog.get_logger("main")
 
 

--- a/scripts/copy-confirm
+++ b/scripts/copy-confirm
@@ -25,7 +25,7 @@ import structlog
 from partisan.exception import RodsError
 
 from npg_irods.exception import ChecksumError
-from npg_irods.utilities import copy
+from npg_irods.utilities import configure_logging, copy
 from npg_irods.version import version
 
 description = """
@@ -97,34 +97,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-
-level = logging.ERROR
-if args.debug:
-    level = logging.DEBUG
-elif args.verbose:
-    level = logging.INFO
-
-logging.basicConfig(
-    level=level,
-    encoding="utf-8",
-)
-
-log_processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.processors.TimeStamper(fmt="iso", utc=True),
-]
-if args.json:
-    log_processors.append(structlog.processors.JSONRenderer())
-else:
-    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
-
-structlog.configure(
-    processors=log_processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
+configure_logging(args.debug, args.verbose, args.colour, args.json)
 log = structlog.get_logger("main")
 
 

--- a/scripts/repair-checksums
+++ b/scripts/repair-checksums
@@ -24,7 +24,7 @@ import sys
 
 import structlog
 
-from npg_irods.utilities import repair_checksums
+from npg_irods.utilities import configure_logging, repair_checksums
 from npg_irods.version import version
 
 description = """
@@ -99,35 +99,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-
-level = logging.ERROR
-if args.debug:
-    level = logging.DEBUG
-elif args.verbose:
-    level = logging.INFO
-
-logging.basicConfig(
-    level=level,
-    encoding="utf-8",
-)
-
-
-log_processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.processors.TimeStamper(fmt="iso", utc=True),
-]
-if args.json:
-    log_processors.append(structlog.processors.JSONRenderer())
-else:
-    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
-
-structlog.configure(
-    processors=log_processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
+configure_logging(args.debug, args.verbose, args.colour, args.json)
 log = structlog.get_logger("main")
 
 

--- a/scripts/repair-common-metadata
+++ b/scripts/repair-common-metadata
@@ -24,7 +24,7 @@ import sys
 
 import structlog
 
-from npg_irods.utilities import repair_common_metadata
+from npg_irods.utilities import configure_logging, repair_common_metadata
 from npg_irods.version import version
 
 description = """
@@ -107,34 +107,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-
-level = logging.ERROR
-if args.debug:
-    level = logging.DEBUG
-elif args.verbose:
-    level = logging.INFO
-
-logging.basicConfig(
-    level=level,
-    encoding="utf-8",
-)
-
-log_processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.processors.TimeStamper(fmt="iso", utc=True),
-]
-if args.json:
-    log_processors.append(structlog.processors.JSONRenderer())
-else:
-    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
-
-structlog.configure(
-    processors=log_processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
+configure_logging(args.debug, args.verbose, args.colour, args.json)
 log = structlog.get_logger("main")
 
 

--- a/scripts/repair-replicas
+++ b/scripts/repair-replicas
@@ -24,7 +24,7 @@ import sys
 
 import structlog
 
-from npg_irods.utilities import repair_replicas
+from npg_irods.utilities import configure_logging, repair_replicas
 from npg_irods.version import version
 
 description = """
@@ -107,34 +107,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-
-level = logging.ERROR
-if args.debug:
-    level = logging.DEBUG
-elif args.verbose:
-    level = logging.INFO
-
-logging.basicConfig(
-    level=level,
-    encoding="utf-8",
-)
-
-log_processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.processors.TimeStamper(fmt="iso", utc=True),
-]
-if args.json:
-    log_processors.append(structlog.processors.JSONRenderer())
-else:
-    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
-
-structlog.configure(
-    processors=log_processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
+configure_logging(args.debug, args.verbose, args.colour, args.json)
 log = structlog.get_logger("main")
 
 

--- a/scripts/safe-remove-script
+++ b/scripts/safe-remove-script
@@ -23,7 +23,7 @@ import logging
 
 import structlog
 
-from npg_irods.utilities import write_safe_remove_script
+from npg_irods.utilities import configure_logging, write_safe_remove_script
 from npg_irods.version import version
 
 description = """
@@ -89,34 +89,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-
-level = logging.ERROR
-if args.debug:
-    level = logging.DEBUG
-elif args.verbose:
-    level = logging.INFO
-
-logging.basicConfig(
-    level=level,
-    encoding="utf-8",
-)
-
-log_processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.processors.TimeStamper(fmt="iso", utc=True),
-]
-if args.json:
-    log_processors.append(structlog.processors.JSONRenderer())
-else:
-    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
-
-structlog.configure(
-    processors=log_processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
+configure_logging(args.debug, args.verbose, args.colour, args.json)
 log = structlog.get_logger("main")
 
 

--- a/scripts/update-ont-metadata
+++ b/scripts/update-ont-metadata
@@ -25,6 +25,8 @@ import dateutil.parser
 from datetime import datetime, timedelta
 import sys
 import structlog
+
+from npg_irods.utilities import configure_logging
 from npg_irods.version import version
 from npg_irods.ont import MetadataUpdate
 import sqlalchemy
@@ -100,34 +102,7 @@ parser.add_argument(
 parser.add_argument("--version", help="Print the version and exit", action="store_true")
 
 args = parser.parse_args()
-
-if args.log_config:
-    logging.config.fileConfig(args.log_config.name)
-else:
-    level = logging.ERROR
-    if args.debug:
-        level = logging.DEBUG
-    elif args.verbose:
-        level = logging.INFO
-
-    logging.basicConfig(level=level, encoding="utf-8", stream=sys.stdout)
-
-log_processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.processors.TimeStamper(fmt="iso", utc=True),
-]
-if args.json:
-    log_processors.append(structlog.processors.JSONRenderer())
-else:
-    log_processors.append(structlog.dev.ConsoleRenderer(colors=args.colour))
-
-structlog.configure(
-    processors=log_processors,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
-
+configure_logging(args.debug, args.verbose, args.colour, args.json)
 log = structlog.get_logger("main")
 
 


### PR DESCRIPTION
Refactor log configuration to use a new common function. Remove local icp wrapper now that partisan supports icp.