### PR TITLE
Add rename on copy for collections

### DIFF
--- a/scripts/copy-confirm
+++ b/scripts/copy-confirm
@@ -25,7 +25,7 @@ from partisan.exception import RodsError
 
 from npg_irods.exception import ChecksumError
 from npg_irods.utilities import copy
-from npg_irods.cli import add_logging_arguments, configure_logging
+from npg_irods.cli import add_logging_arguments, configure_logging, rods_path
 from npg_irods.version import version
 
 description = """
@@ -53,6 +53,7 @@ parser.add_argument(
     "source",
     help="Collection or data object path to copy from. Must be an absolute path.",
     nargs="?",
+    type=rods_path,
 )
 parser.add_argument(
     "destination",

--- a/src/npg_irods/cli.py
+++ b/src/npg_irods/cli.py
@@ -21,9 +21,27 @@ import logging
 import logging.config
 import json as json_parser
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentTypeError
 
 import structlog
+from partisan.irods import rods_path_type
+
+
+def rods_path(path):
+    """Return the iRODS path, if it exists, or raise ArgumentTypeError.
+
+    This function is to be used as an argparse type check.
+
+    Args:
+        path: An iRODS path
+
+    Returns:
+        The path
+    """
+    if rods_path_type(path) is None:
+        raise ArgumentTypeError(f"iRODS path does not exist '{path}'")
+
+    return path
 
 
 def add_logging_arguments(parser: ArgumentParser) -> ArgumentParser:


### PR DESCRIPTION
Previously the copy function would always copy a source collection into a destination collection (which must already exist). This is sometimes not desirable e.g. when we want to copy to a collection with a new name (which doesn't exist, bur whose parent collection does).

This adds this feature. In doing so, it separates the recursive part of the copy operation into a new, private function and adds a new top-level copy function which now handles source and destination path validation and setup required for the rename case.