### PR TITLE
Fix over-zealous permission removal on consent withdrawn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==40.0.2
 ml-warehouse@https://github.com/wtsi-npg/ml-warehouse-python/releases/download/1.3.0/ml-warehouse-1.3.0.tar.gz
-partisan@https://github.com/wtsi-npg/partisan/releases/download/2.2.0/partisan-2.2.0.tar.gz
+partisan@https://github.com/wtsi-npg/partisan/releases/download/2.3.2/partisan-2.3.2.tar.gz
 pymysql==1.0.3
 npg_id_generation@https://github.com/wtsi-npg/npg_id_generation/releases/download/1.0.1/npg_id_generation-1.0.1.tar.gz
 rich==13.3.4

--- a/src/npg_irods/utilities.py
+++ b/src/npg_irods/utilities.py
@@ -28,6 +28,7 @@ import partisan
 from partisan.exception import RodsError
 from partisan.icommands import icp
 from partisan.irods import (
+    AC,
     Collection,
     DataObject,
     RodsItem,
@@ -800,7 +801,7 @@ def _copy(
             log.info(f"Added {n} AVUs", path=d)
         if acl:
             n = d.add_permissions(*s.permissions())
-            log.info(f"Added {n} permissions", path=d)
+            log.info(f"Added {n} permissions", path=d, perm=s.permissions())
 
     def _maybe_copy_obj(s: DataObject, d: DataObject) -> int:
         if exist_ok and d.exists():
@@ -843,10 +844,12 @@ def _copy(
                 src=s,
                 dest=d,
             )
+
             return 0
 
         log.info("Copying collection", src=s, dest=d)
-        coll.create(exist_ok=exist_ok)
+        d.create(exist_ok=exist_ok)
+
         return 1
 
     match (src.rods_type, dest.rods_type):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,6 @@ from npg_irods.db.mlwh import (
     Study,
 )
 from npg_irods.metadata.common import DataFile
-
 from npg_irods.metadata.lims import SeqConcept, TrackedSample
 from npg_irods.metadata.ont import Instrument
 
@@ -642,7 +641,8 @@ def annotated_tree(tmp_path):
     tree_root = rods_path / "tree"
 
     add_test_groups()
-    ac = AC("ss_1000", Permission.READ, zone="testZone")
+    group_ac = AC("ss_1000", Permission.READ, zone="testZone")
+    public_ac = AC("public", Permission.READ, zone="testZone")
 
     coll = Collection(tree_root)
 
@@ -653,17 +653,17 @@ def annotated_tree(tmp_path):
         Collection(c.path / x).create()
 
     coll.add_metadata(AVU("path", str(coll)))
-    coll.add_permissions(ac)
+    coll.add_permissions(group_ac, public_ac)
 
     for item in coll.contents(recurse=True):
         item.add_metadata(AVU("path", str(item)))
-        item.add_permissions(ac)
+        item.add_permissions(group_ac, public_ac)
 
     try:
         yield tree_root
     finally:
         Collection(rods_path).add_permissions(
-            AC(user="irods", perm=Permission.OWN), recurse=True
+            AC(user="irods", perm=Permission.OWN, zone="testZone"), recurse=True
         )
         irm(rods_path, force=True, recurse=True)
         remove_test_groups()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -256,6 +256,26 @@ class TestReplicaUtilities:
 
 @m.describe("Consent utilities")
 class TestConsentUtilities:
+    @m.context("When a data object's consent is withdrawn")
+    @m.it("Has permissions removed, except for the current user and rodsadmins")
+    def test_ensure_consent_withdrawn(self, annotated_tree):
+        obj_paths = collect_obj_paths(Collection(annotated_tree))
+        study_ac = AC("ss_1000", Permission.READ, zone="testZone")
+        admin_ac = AC("irods", Permission.OWN, zone="testZone")
+        public_ac = AC("public", Permission.READ, zone="testZone")
+
+        for p in obj_paths:
+            obj = DataObject(p)
+            assert study_ac in obj.permissions()
+            assert admin_ac in obj.permissions()
+            assert public_ac in obj.permissions()
+
+            ensure_consent_withdrawn(obj)
+
+            assert study_ac not in obj.permissions()
+            assert public_ac not in obj.permissions()
+            assert admin_ac in obj.permissions()
+
     @m.context("When data object consent withdrawn state is checked")
     @m.context("When all of the data objects have consent withdrawn")
     @m.it("Counts successes correctly")


### PR DESCRIPTION
ensure_consent_withdrawn was removing all permissions, including those for the current user and all rodsadmins. This change ensures that necessary admin maintenance permissions remain, while removing all others.