### PR TITLE
Add support for automatically fixing incorrect checksum metadata

### DIFF
--- a/src/npg_irods/utilities.py
+++ b/src/npg_irods/utilities.py
@@ -173,7 +173,7 @@ def repair_checksums(
     - Data object metadata: if all valid replicas have the same checksum and there is
       no checksum metadata AVU, then one is added.
 
-    - Data object metadata: f all valid replicas have the same checksum and current
+    - Data object metadata: if all valid replicas have the same checksum and current
       checksum metadata are incorrect, a new AVU is added and any previous metadata
       moved to history.
 

--- a/src/npg_irods/utilities.py
+++ b/src/npg_irods/utilities.py
@@ -173,6 +173,10 @@ def repair_checksums(
     - Data object metadata: if all valid replicas have the same checksum and there is
       no checksum metadata AVU, then one is added.
 
+    - Data object metadata: f all valid replicas have the same checksum and current
+      checksum metadata are incorrect, a new AVU is added and any previous metadata
+      moved to history.
+
     The following states are not repaired automatically because they require an
     assessment on which, if any, replicas are correct.
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -281,6 +281,7 @@ class TestChecksums:
     @m.context("When a data object has complete checksums")
     @m.context("When a data object has matching checksums")
     @m.context("When there are existing, incorrect checksum metadata")
+    @m.it("Corrects the metadata")
     def test_ensure_matching_checksum_metadata_incorrect(self, simple_data_object):
         obj = DataObject(simple_data_object)
         obj.add_metadata(AVU(DataFile.MD5, "invalid_checksum"))


### PR DESCRIPTION
This change allows some of checksum metadata errors that we encounter in production to be fixed automatically, provided all valid replicas of a data object agree on what the checksum is (i.e. all the valid replicas have a checksum and they are all the same).

has_matching_checksums no longer raises ChecksumError if it encounters multiple incorrect checksum AVUs, but returns False (i.e. reports that there's a mismatch).

ensure_matching_checksum_metadata now fixes any checksum metadata (including multiple incorrect checksum AVUs), but will still ultimately raise ChecksumError if the fix hasn't worked (i.e. the expected correct checksum AVU isn't present in the metadata).