### PR TITLE
Fix ONT permissions updates to retain unmanaged access controls

### DIFF
--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -189,6 +189,19 @@ def ensure_consent_withdrawn_metadata(obj: DataObject) -> bool:
     return _ensure_avus_present(obj, AVU(TrackedSample.CONSENT_WITHDRAWN, 1))
 
 
+def is_managed_access(ac: AC):
+    """Return True if the access control is managed this API and can safely be added or
+    removed.
+
+    Args:
+        ac: The access control to test
+
+    Returns:
+        True if managed by this API.
+    """
+    return STUDY_IDENTIFIER_REGEX.match(ac.user)
+
+
 def has_consent_withdrawn_permissions(obj: DataObject) -> bool:
     """Return True if the object has permissions expected for data with consent
     withdrawn.
@@ -202,9 +215,7 @@ def has_consent_withdrawn_permissions(obj: DataObject) -> bool:
     # Alternatively, we could keep a list of rodsadmin users who should have continued
     # access e.g. in order to redact the data, and check that no other users are in the
     # ACL. Using a list of rodsadmins would mean we don't need to use regex.
-    study_acl = [
-        ac for ac in obj.permissions() if STUDY_IDENTIFIER_REGEX.match(ac.user)
-    ]
+    study_acl = [ac for ac in obj.permissions() if is_managed_access(ac)]
 
     return not study_acl
 

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -190,7 +190,7 @@ def ensure_consent_withdrawn_metadata(obj: DataObject) -> bool:
 
 
 def is_managed_access(ac: AC):
-    """Return True if the access control is managed this API and can safely be added or
+    """Return True if the access control is managed by this API and can safely be added or
     removed.
 
     Args:

--- a/tests/test_ont.py
+++ b/tests/test_ont.py
@@ -49,10 +49,13 @@ class TestONT(object):
         ]:
             assert avu in coll.metadata(), f"{avu} is in {coll} metadata"
 
-        ac = AC("ss_2000", Permission.READ, zone="testZone")
-        assert ac in coll.acl()
+        expected_acl = [
+            AC("irods", Permission.OWN, zone="testZone"),
+            AC("ss_2000", Permission.READ, zone="testZone"),
+        ]
+        assert coll.acl() == expected_acl
         for item in coll.contents():
-            assert ac in item.acl(), f"{ac} is in {item} ACL"
+            assert item.acl() == expected_acl
 
     @tests_have_admin
     @m.context("When the experiment is multiplexed")
@@ -100,10 +103,14 @@ class TestONT(object):
                 ]:
                     assert avu in bc_coll.metadata(), f"{avu} is in {bc_coll} metadata"
 
-                ac = AC("ss_3000", Permission.READ, zone="testZone")
-                assert ac in bc_coll.acl(), f"{ac} is in {bc_coll} ACL"
+                expected_acl = [
+                    AC("irods", Permission.OWN, zone="testZone"),
+                    AC("ss_3000", Permission.READ, zone="testZone"),
+                ]
+
+                assert bc_coll.acl() == expected_acl
                 for item in bc_coll.contents():
-                    assert ac in item.acl(), f"{ac} is in {item} ACL"
+                    assert item.acl() == expected_acl
 
 
 class TestMetadataUpdate(object):


### PR DESCRIPTION
iRODS permissions updates were removing permissions that were not intended for removal e.g. for the current user. The unit tests were not good enough to pick detect this problem.

This change ensures that only permissions managed by this API are removed during updates.