### PR TITLE
Refactor to separate initial ONT metadata creation from later regular updates

### DIFF
--- a/scripts/locate-data-objects
+++ b/scripts/locate-data-objects
@@ -26,7 +26,7 @@ import structlog
 from partisan.irods import AVU, query_metadata
 from sqlalchemy.orm import Session
 
-from npg_irods import illumina
+from npg_irods import illumina, ont
 from npg_irods.cli import add_logging_arguments, configure_logging, parse_iso_date
 from npg_irods.db import DBConfig
 from npg_irods.db.mlwh import find_consent_withdrawn_samples
@@ -110,16 +110,15 @@ cwdr_parser.set_defaults(func=consent_withdrawn)
 
 ilup_parser = subparsers.add_parser(
     "illumina-updates",
-    help="Find data objects which are the components of Illumina runs, whose tracking "
+    help="Find data objects, which are components of Illumina runs, whose tracking "
     "metadata in the ML warehouse have changed since a specified time.",
 )
 ilup_parser.add_argument(
     "--begin-date",
     "--begin_date",
-    help="Limit data object found to those changed after this date. "
-    "Defaults to 14 days ago. "
-    "The argument must be an ISO8601 UTC date or date and time e.g. 2022-01-30, "
-    "2022-01-30T11:11:03Z",
+    help="Limit data objects found to those changed after this date. Defaults to 14 "
+    "days ago. The argument must be an ISO8601 UTC date or date and time e.g. "
+    "2022-01-30, 2022-01-30T11:11:03Z",
     type=parse_iso_date,
     default=datetime.now(timezone.utc) - timedelta(days=14),
 )
@@ -139,15 +138,14 @@ def illumina_updates(cli_args):
             log.info("Finding data objects", item=i, component=c, since=iso_date)
 
             try:
-                for obj in query_metadata(
+                avus = [
                     AVU(Instrument.RUN, c.id_run),
                     AVU(Instrument.LANE, c.position),
                     AVU(SeqConcept.TAG_INDEX, c.tag_index),
-                    data_object=True,
-                    collection=False,
-                    zone=cli_args.zone,
-                ):
+                ]
+                for obj in query_metadata(*avus, collection=False, zone=cli_args.zone):
                     print(obj)
+
             except Exception as e:
                 num_errors += 1
                 log.error(e, item=i, component=c)
@@ -158,6 +156,62 @@ def illumina_updates(cli_args):
 
 
 ilup_parser.set_defaults(func=illumina_updates)
+
+
+ontup_parser = subparsers.add_parser(
+    "ont-updates",
+    help="Find data objects, which are components of ONT runs, whose tracking metadata "
+    "in the ML warehouse have changed since a specified time.",
+)
+ontup_parser.add_argument(
+    "--begin-date",
+    "--begin_date",
+    help="Limit data objects found to those changed after this date. Defaults to 14 "
+    "days ago. The argument must be an ISO8601 UTC date or date and time e.g. "
+    "2022-01-30, 2022-01-30T11:11:03Z",
+    type=parse_iso_date,
+    default=datetime.now(timezone.utc) - timedelta(days=14),
+)
+
+
+def ont_updates(cli_args):
+    dbconfig = DBConfig.from_file(cli_args.database_config.name, "mlwh_ro")
+    engine = sqlalchemy.create_engine(dbconfig.url)
+    with Session(engine) as session:
+        num_processed = num_errors = 0
+        iso_date = cli_args.begin_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        for i, c in enumerate(
+            ont.find_components_changed(
+                session, include_tags=False, since=cli_args.begin_date
+            )
+        ):
+            num_processed += 1
+            log.info("Finding collections", item=i, component=c, since=iso_date)
+
+            try:
+                avus = [
+                    AVU(ont.Instrument.EXPERIMENT_NAME, c.experiment_name),
+                    AVU(ont.Instrument.INSTRUMENT_SLOT, c.instrument_slot),
+                ]
+                if c.tag_identifier is not None:
+                    avus.append(AVU(ont.Instrument.TAG_IDENTIFIER, c.tag_identifier))
+
+                for coll in query_metadata(
+                    *avus, data_object=False, zone=cli_args.zone
+                ):
+                    print(coll)
+
+            except Exception as e:
+                num_errors += 1
+                log.error(e, item=i, component=c)
+
+        log.info(f"Processed {num_processed} with {num_errors} errors")
+        if num_errors:
+            exit(1)
+
+
+ontup_parser.set_defaults(func=ont_updates)
 
 args = parser.parse_args()
 configure_logging(

--- a/scripts/update-ont-metadata
+++ b/scripts/update-ont-metadata
@@ -27,7 +27,7 @@ from sqlalchemy.orm import Session
 
 from npg_irods.cli import add_logging_arguments, configure_logging, parse_iso_date
 from npg_irods.db import DBConfig
-from npg_irods.ont import MetadataUpdate
+from npg_irods.ont import update_metadata
 from npg_irods.version import version
 
 description = """
@@ -94,9 +94,8 @@ def main():
 
     engine = sqlalchemy.create_engine(dbconfig.url)
     with Session(engine) as session:
-        mu = MetadataUpdate(zone=args.zone)
-        num_processed, num_updated, num_errors = mu.update_secondary_metadata(
-            session, since=args.begin_date
+        num_processed, num_updated, num_errors = update_metadata(
+            session, since=args.begin_date, zone=args.zone
         )
 
         if num_errors:

--- a/src/npg_irods/metadata/ont.py
+++ b/src/npg_irods/metadata/ont.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2021, 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2021, 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@ class Instrument(AsValueEnum, metaclass=with_namespace("ont")):
 
     EXPERIMENT_NAME = "experiment_name"
     INSTRUMENT_SLOT = "instrument_slot"
+    TAG_IDENTIFIER = "tag_identifier"
 
     def __repr__(self):
         return f"{Instrument.namespace}:{self.value}"

--- a/src/npg_irods/ont.py
+++ b/src/npg_irods/ont.py
@@ -23,7 +23,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from os import PathLike
-from typing import Optional, Type
+from typing import Iterator, Optional, Type
 
 from partisan.exception import RodsError
 from partisan.irods import AVU, Collection, DataObject, query_metadata
@@ -31,8 +31,9 @@ from sqlalchemy import asc, distinct
 from sqlalchemy.orm import Session
 from structlog import get_logger
 
-from npg_irods.db.mlwh import OseqFlowcell
-from npg_irods.metadata.common import SeqConcept, SeqSubset
+from npg_irods.common import do_metadata_update, do_permissions_update, infer_zone
+from npg_irods.db.mlwh import OseqFlowcell, Sample, Study
+from npg_irods.metadata.common import SeqConcept
 from npg_irods.metadata.lims import (
     is_managed_access,
     make_public_read_acl,
@@ -56,136 +57,336 @@ IGNORED_DIRECTORIES = ["other_reports"]
 
 @dataclass(order=True)
 class Component:
+    """A set of reads from an ONT sequencing run."""
+
     experiment_name: str
-    position: int
-    tag_index: Optional[int]
-    subset: Optional[SeqSubset]
+    """The experiment name recorded in MinKNOW."""
+    instrument_slot: int
+    """The 1-based instrument slot index where the flowcell was run."""
 
-
-class MetadataUpdate:
-    """Performs updated on metadata of data objects and collections for ONT data in
-    iRODS."""
+    tag_identifier: Optional[str]
+    """The tag identifier, if the reads are from a multiplexed pool."""
 
     def __init__(
-        self, experiment_name: str = None, instrument_slot: int = None, zone: str = None
+        self, experiment_name: str, instrument_slot: int, tag_identifier: str = None
     ):
-        """Create a new metadata updater for the specified ONT run.
-
-        Args:
-            experiment_name: The ONT experiment name. Optional; provide this to limit
-                the updates to only that experiment.
-            instrument_slot: The ONT instrument slot number. Optional; provide this to
-                limit the updates to only that slot.
-            zone: The iRODS zone where the data are located. Optional; provide this to
-                update on an iRODS zone other than local (i.e. on a federated zone)
-        """
-
         self.experiment_name = experiment_name
         self.instrument_slot = instrument_slot
-        self.zone = zone
+        self.tag_identifier = tag_identifier
 
-    def update_secondary_metadata(
-        self, mlwh_session: Session, since: datetime = None
-    ) -> (int, int, int):
-        """Update iRODS secondary metadata on ONT run collections whose corresponding
-        ML warehouse records have been updated more recently than the specified time.
 
-        Collections to update are identified by having ont:experiment_name and
-        ont:instrument_slot metadata already attached to them. This is done for example,
-        by the process which moves sequence data from the instrument into iRODS.
+def update_metadata(
+    mlwh_session: Session,
+    experiment_name=None,
+    instrument_slot=None,
+    since: datetime = None,
+    zone=None,
+) -> (int, int, int):
+    """Update iRODS metadata on ONT run collections whose corresponding ML warehouse
+    records have been updated at, or more recently than, the specified time.
 
-        Args:
-            mlwh_session: An open SQL session.
-            since: A datetime.
+    Collections to update are identified by having ont:experiment_name and
+    ont:instrument_slot metadata already attached to them. This is done for example,
+    by the process which moves sequence data from the instrument into iRODS.
 
-        Returns:
-            A tuple of the number of paths found, the number of paths whose metadata
-        was updated and the number of errors encountered.
-        """
-        if since is None:
-            since = datetime.fromtimestamp(0)  # Everything since the Epoch
+    Args:
+        mlwh_session: An open SQL session.
+        experiment_name: Limit updates to this experiment. Optional.
+        instrument_slot: Limit updates to this instrument slot. Optional, requires
+          an experiment_name to be supplied.
+        since: A datetime. Limit updates to experiments changed at this time or later.
+        zone: The iRODS zone to search for metadata to update.
 
-        num_found, num_updated, num_errors = 0, 0, 0
+    Returns:
+        A tuple of the number of paths found, the number of paths whose metadata
+    was updated and the number of errors encountered.
+    """
+    if since is None:
+        since = datetime.fromtimestamp(0)  # Everything since the Epoch
+
+    if experiment_name is None and instrument_slot is not None:
+        raise ValueError(
+            f"An instrument_slot {instrument_slot} was supplied "
+            "without an experiment_name"
+        )
+
+    num_found, num_updated, num_errors = 0, 0, 0
+
+    for i, c in enumerate(
+        find_components_changed(mlwh_session, include_tags=False, since=since)
+    ):
+        if experiment_name is not None and c.experiment_name != experiment_name:
+            continue
+        if instrument_slot is not None and c.instrument_slot != instrument_slot:
+            continue
+
+        avus = [
+            AVU(Instrument.EXPERIMENT_NAME, c.experiment_name),
+            AVU(Instrument.INSTRUMENT_SLOT, c.instrument_slot),
+        ]
 
         try:
-            expt_slots = find_recent_expt_slot(mlwh_session, since=since)
-        except Exception as e:
+            log.info("Searching", item=i, comp=c, zone=zone)
+            colls = query_metadata(*avus, data_object=False, zone=zone)
+
+            num_colls = len(colls)
+            num_found += num_colls
+            if num_colls:
+                log.info("Found collections", item=i, comp=c, num_coll=num_colls)
+            else:
+                log.warn("Found no collections", item=i, comp=c)
+
+            for coll in colls:
+                try:
+                    if annotate_results_collection(coll, c, mlwh_session):
+                        log.info("Updated", item=i, path=coll, comp=c)
+                        num_updated += 1
+                    else:
+                        num_errors += 1
+                except RodsError as re1:
+                    log.error(re1.message, item=i, code=re1.code)
+                    num_errors += 1
+
+        except RodsError as re2:
+            log.error(re2.message, item=i, code=re2.code)
             num_errors += 1
+        except Exception as e:
             log.error(e)
-            return num_found, num_updated, num_errors
+            num_errors += 1
 
-        for expt_name, slot in expt_slots:
-            expt_avu = AVU(Instrument.EXPERIMENT_NAME, expt_name)
-            slot_avu = AVU(Instrument.INSTRUMENT_SLOT, slot)
+    return num_found, num_updated, num_errors
 
+
+def annotate_results_collection(
+    path: PathLike | str, component: Component, mlwh_session: Session
+) -> bool:
+    """Add or update metadata on an existing iRODS collection containing ONT data.
+
+    The metadata added are fetched from the ML warehouse and include information on the
+    sample and the associated study, including data access permissions. This function
+    also sets the appropriate permissions in iRODS.
+
+    This function is idempotent. No harm will come from running it on an already
+    up-to-date collection.
+
+    Args:
+        path: A collection path to annotate.
+        component: A Component describing the portion of an instrument
+        mlwh_session: An open SQL session.
+
+    Returns:
+        True on success.
+    """
+    c = component
+    log.debug("Searching the ML warehouse", comp=c)
+
+    flowcells = find_flowcells_by_component(mlwh_session, c)
+    if not flowcells:
+        log.warn("Failed to find flowcell information in the ML warehouse", comp=c)
+        return False
+
+    coll = Collection(path)
+    if not coll.exists():
+        log.warn("Collection does not exist", path=coll, comp=c)
+        return False
+
+    avus = [
+        AVU(Instrument.EXPERIMENT_NAME, c.experiment_name),
+        AVU(Instrument.INSTRUMENT_SLOT, c.instrument_slot),
+    ]
+    coll.supersede_metadata(*avus)  # These AVUs should be present already
+
+    # A single fc record (for non-multiplexed data)
+    if len(flowcells) == 1:
+        log.info("Found non-multiplexed", comp=c)
+        try:
+            # Secondary metadata. Updating this here is an optimisation to reduce
+            # turn-around-time. If we don't update, we just have to wait for a
+            # cron job to call `ensure_secondary_metadata_updated`.
+            _do_metadata_and_permissions_update(coll, flowcells)
+        except RodsError as e:
+            log.error(e.message, code=e.code)
+            return False
+
+        return True
+
+    log.info("Found multiplexed", comp=c)
+    num_errors = 0
+
+    # Since the run report files are outside the 'root' collection for
+    # multiplexed runs, their permissions must be set explicitly
+    num_errors += _set_minknow_reports_public(coll)
+
+    sub_colls = [item for item in coll.contents() if item.rods_type == Collection]
+
+    # This expects the barcode directory naming style created by current ONT's
+    # Guppy de-multiplexer which creates several subdirectories e.g. "fast5_pass",
+    # "fast_fail". Each of these subdirectories contains another directory for each
+    # barcode, plus miscellaneous directories such as "mixed" and "unclassified".
+
+    for sc in sub_colls:  # fast5_fail, fast5_pass etc
+        # These are some known special cases that don't have barcode directories
+        if sc.path.name in IGNORED_DIRECTORIES:
+            log.debug("Ignoring", path=sc)
+            continue
+
+        # Multiple fc records (one per plex of multiplexed data)
+        for fc in flowcells:
             try:
-                if self.experiment_name is not None:
-                    if self.experiment_name != expt_name:
-                        log.info(
-                            "Skipping on experiment name",
-                            expt_name=expt_name,
-                            slot=slot,
-                        )
-                        continue
-                    if self.instrument_slot is not None:
-                        if self.instrument_slot != slot:
-                            log.info(
-                                "Skipping on slot",
-                                expt_name=expt_name,
-                                slot=slot,
-                            )
-                            continue
+                bpath = sc.path / barcode_name_from_id(fc.tag_identifier)
+                bcoll = Collection(bpath)
+                bcomp = Component(
+                    c.experiment_name, c.instrument_slot, fc.tag_identifier
+                )
+                if not bcoll.exists():
+                    log.warn("Collection missing", path=bpath, comp=bcomp)
+                    continue
 
-                log.info("Searching", expt_name=expt_name, slot=slot, zone=self.zone)
-                colls = query_metadata(
-                    expt_avu,
-                    slot_avu,
-                    collection=True,
-                    data_object=False,
-                    zone=self.zone,
+                log.info(
+                    "Annotating",
+                    path=bcoll,
+                    comp=bcomp,
+                    sample=fc.sample,
+                    study=fc.study,
                 )
 
-                num_colls = len(colls)
-                num_found += num_colls
-                if num_colls:
-                    log.info(
-                        "Found collections",
-                        expt_name=expt_name,
-                        slot=slot,
-                        num_coll=num_colls,
-                    )
-                else:
-                    log.warn("Found no collections", expt_name=expt_name, slot=slot)
+                # Primary metadata. We are adding the full tag identifier to enable ML
+                # warehouse lookup given just an iRODS path as a starting point. The tag
+                # identifier to tag index transformation loses information (the tag
+                # prefix), so the existing tag index AVU doesn't allow this.
+                bcoll.supersede_metadata(
+                    AVU(Instrument.TAG_IDENTIFIER, fc.tag_identifier),
+                    AVU(SeqConcept.TAG_INDEX, tag_index_from_id(fc.tag_identifier)),
+                    history=True,
+                )
 
-                for coll in colls:
-                    try:
-                        if annotate_results_collection(
-                            coll, expt_name, slot, mlwh_session
-                        ):
-                            log.info(
-                                "Updated", expt_name=expt_name, slot=slot, path=coll
-                            )
-                            num_updated += 1
-                        else:
-                            num_errors += 1
-                    except RodsError as re1:
-                        log.error(re1.message, code=re1.code)
-                        num_errors += 1
+                # Secondary metadata. Updating this here is an optimisation to reduce
+                # turn-around-time. If we don't update, we just have to wait for a
+                # cron job to call `ensure_secondary_metadata_updated`.
+                _do_metadata_and_permissions_update(bcoll, [fc])
 
-            except RodsError as re2:
-                log.error(re2.message, code=re2.code)
-                num_errors += 1
-            except Exception as e:
-                log.error(e)
+            except RodsError as e:
+                log.error(e.message, code=e.code)
                 num_errors += 1
 
-        return num_found, num_updated, num_errors
+    return num_errors == 0
 
-    def __str__(self):
-        return (
-            f"<MetadataUpdate expt_name={self.experiment_name} "
-            f"slot={self.instrument_slot}>"
+
+def ensure_secondary_metadata_updated(
+    item: Collection | DataObject, mlwh_session
+) -> bool:
+    """Update secondary metadata on an iRODS path, using information from the ML
+    warehouse.
+
+    Args:
+        item: iRODS path to update.
+        mlwh_session: An open SQL session.
+
+    Returns:
+        True if any changes were made.
+    """
+    expt = item.avu(Instrument.EXPERIMENT_NAME.value)
+    slot = item.avu(Instrument.INSTRUMENT_SLOT.value)
+    tag_id = item.avu(Instrument.TAG_IDENTIFIER.value)
+
+    component = Component(expt.value, slot.value, tag_id.value)
+    flowcells = find_flowcells_by_component(mlwh_session, component)
+
+    return _do_metadata_and_permissions_update(item, flowcells)
+
+
+def find_recent_expt(sess: Session, since: datetime) -> list[str]:
+    """Find recent ONT experiments in the ML warehouse database.
+
+    Find ONT experiments in the ML warehouse database that have been updated
+    at, or since a specified date and time. If any element of the experiment (any of
+    the positions in a multi-flowcell experiment, any of the multiplexed
+    elements within a position) have been updated in the query window, the
+    experiment name will be returned.
+
+    Args:
+        sess: An open session to the ML warehouse.
+        since: A datetime.
+
+    Returns:
+        List of matching experiment name strings
+    """
+
+    rows = (
+        sess.query(distinct(OseqFlowcell.experiment_name))
+        .filter(OseqFlowcell.recorded_at >= since)
+        .all()
+    )
+
+    return [val for val, in rows]
+
+
+def find_components_changed(
+    sess: Session, since: datetime, include_tags=True
+) -> Iterator[Component]:
+    """Return the components of runs whose ML warehouse metadata has been updated
+    at or since the given date and time.
+
+    Args:
+        sess: An open SQL session.
+        since: A datetime.
+        include_tags: Resolve the components to the granularity of individual tags,
+          rather than as whole runs. Optional, defaults to True.
+
+    Returns:
+        An iterator over the matching components.
+    """
+    columns = [OseqFlowcell.experiment_name, OseqFlowcell.instrument_slot]
+
+    if include_tags:
+        columns.append(OseqFlowcell.tag_identifier)
+
+    for cols in (
+        sess.query(*columns)
+        .distinct()
+        .join(OseqFlowcell.sample)
+        .join(OseqFlowcell.study)
+        .filter(
+            (Sample.recorded_at >= since)
+            | (Study.recorded_at >= since)
+            | (OseqFlowcell.recorded_at >= since)
         )
+        .group_by(OseqFlowcell.experiment_name, OseqFlowcell.instrument_slot)
+        .order_by(asc(OseqFlowcell.experiment_name), asc(OseqFlowcell.instrument_slot))
+    ):
+        yield Component(*cols)
+
+
+def find_flowcells_by_component(
+    sess: Session, component: Component
+) -> list[Type[OseqFlowcell]]:
+    """Return the flowcells for this component.
+
+    Args:
+        sess: An open SQL session.
+        component: An ONT run component.
+
+    Returns:
+        The OseqFlowcells for the component.
+    """
+    query = (
+        sess.query(OseqFlowcell)
+        .distinct()
+        .filter(OseqFlowcell.experiment_name == component.experiment_name)
+    )
+
+    if component.instrument_slot is not None:
+        query = query.filter(OseqFlowcell.instrument_slot == component.instrument_slot)
+
+    if component.tag_identifier is not None:
+        query = query.filter(OseqFlowcell.tag_identifier.like())
+
+    return query.order_by(
+        asc(OseqFlowcell.experiment_name),
+        asc(OseqFlowcell.instrument_slot),
+        asc(OseqFlowcell.tag_identifier),
+        asc(OseqFlowcell.tag2_identifier),
+    ).all()
 
 
 def tag_index_from_id(tag_identifier: str) -> int:
@@ -219,253 +420,64 @@ def barcode_name_from_id(tag_identifier: str) -> str:
     )
 
 
-def annotate_results_collection(
-    path: PathLike | str,
-    experiment_name: str,
-    instrument_slot: int,
-    mlwh_session: Session,
+def _do_metadata_and_permissions_update(
+    item: Collection | DataObject, flowcells
 ) -> bool:
-    """Add or update metadata on an existing iRODS collection containing ONT data.
-
-    The metadata added are fetched from the ML warehouse and include information on the
-    sample and the associated study, including data access permissions. This function
-    also sets the appropriate permissions in iRODS.
-
-    This function is idempotent. No harm will come from running it on an already
-    up-to-date collection.
+    """Update metadata and permissions using sample/study information obtained from
+    flowcell records in the ML warehouse.
 
     Args:
-        path: A collection path to annotate.
-        experiment_name: The ONT experiment name.
-        instrument_slot: The ONT instrument slot number.
-        mlwh_session: An open SQL session.
+        item: iRODS path to update.
+        flowcells: ML warehouse flowcell records.
 
     Returns:
-        True on success.
+        True if changes were made.
     """
-    log.debug(
-        "Searching the ML warehouse", expt_name=experiment_name, slot=instrument_slot
+    zone = infer_zone(item)
+
+    metadata = []
+    for fc in flowcells:
+        metadata.extend(make_sample_metadata(fc.sample))
+        metadata.extend(make_study_metadata(fc.study))
+    meta_updated = do_metadata_update(item, metadata)
+
+    acl = []
+    for fc in flowcells:
+        acl.extend(make_sample_acl(fc.sample, fc.study, zone=zone))
+    perm_updated = do_permissions_update(
+        item, acl, recurse=(item.rods_type == Collection)
     )
 
-    fc_info = find_flowcell_by_expt_slot(mlwh_session, experiment_name, instrument_slot)
-    if not fc_info:
-        log.warn(
-            "Failed to find flowcell information in the ML warehouse",
-            expt_name=experiment_name,
-            slot=instrument_slot,
-        )
-        return False
+    return meta_updated or perm_updated
 
-    coll = Collection(path)
-    if not coll.exists():
-        log.warn(
-            "Collection does not exist",
-            path=coll,
-            expt_name=experiment_name,
-            slot=instrument_slot,
-        )
-        return False
 
-    avus = [
-        AVU(Instrument.EXPERIMENT_NAME, experiment_name),
-        AVU(Instrument.INSTRUMENT_SLOT, instrument_slot),
-    ]
-    coll.supersede_metadata(*avus)  # These AVUs should be present already
+def _set_minknow_reports_public(coll: Collection) -> int:
+    """Set the permissions of any MinKNOW reports directly in the collection to
+    public:read.
 
-    # A single fc record (for non-multiplexed data)
-    if len(fc_info) == 1:
-        log.info(
-            "Found non-multiplexed", expt_name=experiment_name, slot=instrument_slot
-        )
-        fc = fc_info[0]
-        try:
-            coll.supersede_metadata(*make_study_metadata(fc.study), history=True)
-            coll.supersede_metadata(*make_sample_metadata(fc.sample), history=True)
+    Args:
+        coll: A collection containing report data objects.
 
-            # Keep the access controls that we don't manage
-            keep = [ac for ac in coll.permissions() if not is_managed_access(ac)]
-            coll.supersede_permissions(
-                *keep, *make_sample_acl(fc.sample, fc.study), recurse=True
-            )
-        except RodsError as e:
-            log.error(e.message, code=e.code)
-            return False
-
-        return True
-
-    log.info("Found multiplexed", expt_name=experiment_name, slot=instrument_slot)
+    Returns:
+        The number of errors encountered.
+    """
     num_errors = 0
 
-    # Since the run report files are outside the 'root' collection for
-    # multiplexed runs, their permissions must be set explicitly
     reports = [
         obj
         for obj in coll.contents()
-        if "report" in str(obj.path) and obj.rods_type == DataObject
+        if obj.rods_type == DataObject and "report" in obj.name
     ]
+
     for report in reports:
         try:
             if report.exists():
-                log.info(
-                    "Updating run report permissions",
-                    path=report.path,
-                    expt_name=experiment_name,
-                    slot=instrument_slot,
-                )
+                log.info("Updating run report permissions", path=report.path)
                 keep = [ac for ac in report.permissions() if not is_managed_access(ac)]
                 report.supersede_permissions(*keep, *make_public_read_acl())
             else:
-                log.warn(
-                    "Run report missing",
-                    path=report.path,
-                    expt_name=experiment_name,
-                    slot=instrument_slot,
-                )
+                log.warn("Run report missing", path=report.path)
         except RodsError as e:
             log.error(e.message, code=e.code)
             num_errors += 1
-
-    sub_colls = [c for c in coll.contents() if c.rods_type == Collection]
-
-    # This expects the barcode directory naming style created by current ONT's
-    # Guppy de-multiplexer which creates several subdirectories e.g. "fast5_pass",
-    # "fast_fail". Each of these subdirectories contains another directory for each
-    # barcode, plus miscellaneous directories such as "mixed" and "unclassified".
-
-    for sc in sub_colls:  # fast5_fail, fast5_pass etc
-        # These are some known special cases that don't have barcode directories
-        if sc.path.name in IGNORED_DIRECTORIES:
-            log.debug("Ignoring", path=sc)
-            continue
-
-        # Multiple fc records (one per plex of multiplexed data)
-        for fc in fc_info:
-            try:
-                bc_path = sc.path / barcode_name_from_id(fc.tag_identifier)
-                bc_coll = Collection(bc_path)
-                if not bc_coll.exists():
-                    log.warn(
-                        "Collection missing",
-                        path=bc_path,
-                        expt_name=experiment_name,
-                        slot=instrument_slot,
-                        tag_id=fc.tag_identifier,
-                    )
-                    continue
-
-                log.info(
-                    "Annotating",
-                    path=bc_coll,
-                    expt_name=experiment_name,
-                    slot=instrument_slot,
-                    tag_id=fc.tag_identifier,
-                    sample=fc.sample,
-                    study=fc.study,
-                )
-
-                bc_coll.supersede_metadata(
-                    AVU(SeqConcept.TAG_INDEX, tag_index_from_id(fc.tag_identifier)),
-                    history=True,
-                )
-                bc_coll.supersede_metadata(*make_study_metadata(fc.study), history=True)
-                bc_coll.supersede_metadata(
-                    *make_sample_metadata(fc.sample), history=True
-                )
-
-                # The ACL could be different for each plex
-                # Keep the access controls that we don't manage
-                keep = [ac for ac in bc_coll.permissions() if not is_managed_access(ac)]
-                bc_coll.supersede_permissions(
-                    *keep, *make_sample_acl(fc.sample, fc.study), recurse=True
-                )
-            except RodsError as e:
-                log.error(e.message, code=e.code)
-                num_errors += 1
-
-    return num_errors == 0
-
-
-def find_recent_expt(sess: Session, since: datetime) -> list[str]:
-    """Find recent ONT experiments in the ML warehouse database.
-
-    Find ONT experiments in the ML warehouse database that have been updated
-    since a specified date and time. If any element of the experiment (any of
-    the positions in a multi-flowcell experiment, any of the multiplexed
-    elements within a position) have been updated in the query window, the
-    experiment name will be returned.
-
-    Args:
-        sess: An open session to the ML warehouse.
-        since: A datetime.
-
-    Returns:
-        List of matching experiment name strings
-    """
-
-    rows = (
-        sess.query(distinct(OseqFlowcell.experiment_name))
-        .filter(OseqFlowcell.last_updated >= since)
-        .all()
-    )
-
-    return [val for val, in rows]
-
-
-def find_recent_expt_slot(sess: Session, since: datetime) -> list[tuple]:
-    """Find recent ONT experiments and instrument slot positions in the ML
-    warehouse database.
-
-    Find ONT experiments and associated instrument slot positions in the ML
-    warehouse database that have been updated since a specified date and time.
-
-    Args:
-        sess: An open session to the ML warehouse.
-        since: A datetime.
-
-    Returns:
-        List of matching (experiment name, slot position) tuples
-    """
-    rows = (
-        sess.query(OseqFlowcell.experiment_name, OseqFlowcell.instrument_slot)
-        .filter(OseqFlowcell.last_updated >= since)
-        .group_by(OseqFlowcell.experiment_name, OseqFlowcell.instrument_slot)
-        .order_by(asc(OseqFlowcell.experiment_name), asc(OseqFlowcell.instrument_slot))
-        .all()
-    )
-    return [row.tuple() for row in rows]
-
-
-def find_flowcell_by_expt_slot(
-    sess: Session, experiment_name: str, instrument_slot: int
-) -> list[Type[OseqFlowcell]]:
-    return (
-        sess.query(OseqFlowcell)
-        .filter(
-            OseqFlowcell.experiment_name == experiment_name,
-            OseqFlowcell.instrument_slot == instrument_slot,
-        )
-        .order_by(
-            asc(OseqFlowcell.experiment_name),
-            asc(OseqFlowcell.instrument_slot),
-            asc(OseqFlowcell.tag_identifier),
-            asc(OseqFlowcell.tag2_identifier),
-        )
-        .all()
-    )
-
-
-def find_flowcells_by_component(sess: Session, component: Component):
-    return (
-        sess.query(OseqFlowcell)
-        .filter(
-            OseqFlowcell.experiment_name == component.experiment_name,
-            OseqFlowcell.instrument_slot == component.position,
-        )
-        .order_by(
-            asc(OseqFlowcell.experiment_name),
-            asc(OseqFlowcell.instrument_slot),
-            asc(OseqFlowcell.tag_identifier),
-            asc(OseqFlowcell.tag2_identifier),
-        )
-        .all()
-    )
+    return num_errors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,7 +254,7 @@ def initialize_mlwh_ont_synthetic(session: Session):
 
             # All the even experiments have the early datetime
             # All the odd experiments have the late datetime
-            when_expt = EARLY if expt % 2 == 0 else LATE
+            when = EARLY if expt % 2 == 0 else LATE
 
             flowcells.append(
                 OseqFlowcell(
@@ -266,8 +266,8 @@ def initialize_mlwh_ont_synthetic(session: Session):
                     id_lims=f"Example LIMS ID {sample_idx}",
                     id_flowcell_lims=id_flowcell,
                     requested_data_type=req_data_type,
-                    last_updated=when_expt,
-                    recorded_at=BEGIN,
+                    last_updated=when,
+                    recorded_at=when,
                 )
             )
             sample_idx += 1
@@ -325,7 +325,7 @@ def initialize_mlwh_ont_synthetic(session: Session):
                         tag_sequence=barcode,
                         tag_identifier=tag_id,
                         last_updated=when,
-                        recorded_at=BEGIN,
+                        recorded_at=when,
                     )
                 )
                 msample_idx += 1

--- a/tests/test_illumina.py
+++ b/tests/test_illumina.py
@@ -80,7 +80,7 @@ class TestIlluminaMetadataUpdate(object):
             assert avu in obj.metadata()
 
         assert not ensure_secondary_metadata_updated(
-            obj, mlwh_session=illumina_synthetic_mlwh, zone=zone
+            obj, mlwh_session=illumina_synthetic_mlwh
         )
 
         for avu in expected_avus:
@@ -275,7 +275,7 @@ class TestIlluminaPermissionsUpdate:
 
         assert obj.permissions() == [AC("irods", perm=Permission.OWN, zone=zone)]
         assert ensure_secondary_metadata_updated(
-            obj, mlwh_session=illumina_synthetic_mlwh, zone=zone
+            obj, mlwh_session=illumina_synthetic_mlwh
         )
         assert obj.permissions() == [
             AC("irods", perm=Permission.OWN, zone=zone),
@@ -310,7 +310,7 @@ class TestIlluminaPermissionsUpdate:
 
         assert obj.permissions() == expected_acl
         assert not ensure_secondary_metadata_updated(
-            obj, mlwh_session=illumina_synthetic_mlwh, zone=zone
+            obj, mlwh_session=illumina_synthetic_mlwh
         )
         assert obj.permissions() == expected_acl
 
@@ -331,7 +331,7 @@ class TestIlluminaPermissionsUpdate:
 
         assert obj.permissions() == old_permissions
         assert ensure_secondary_metadata_updated(
-            obj, mlwh_session=illumina_synthetic_mlwh, zone=zone
+            obj, mlwh_session=illumina_synthetic_mlwh
         )
         new_permissions = [
             AC("irods", perm=Permission.OWN, zone=zone),
@@ -356,7 +356,7 @@ class TestIlluminaPermissionsUpdate:
 
         assert obj.permissions() == expected_acl
         assert ensure_secondary_metadata_updated(
-            obj, mlwh_session=illumina_synthetic_mlwh, zone=zone
+            obj, mlwh_session=illumina_synthetic_mlwh
         )
         assert obj.permissions() == [AC("irods", perm=Permission.OWN, zone=zone)]
 
@@ -377,7 +377,7 @@ class TestIlluminaPermissionsUpdate:
 
         assert obj.permissions() == expected_acl
         assert ensure_secondary_metadata_updated(
-            obj, mlwh_session=illumina_synthetic_mlwh, zone=zone
+            obj, mlwh_session=illumina_synthetic_mlwh
         )
         assert obj.permissions() == [AC("irods", perm=Permission.OWN, zone=zone)]
 

--- a/tests/test_ml_warehouse_queries.py
+++ b/tests/test_ml_warehouse_queries.py
@@ -24,7 +24,7 @@ from pytest import mark as m
 from conftest import BEGIN, EARLY, LATE, LATEST
 from npg_irods.metadata import illumina
 from npg_irods.metadata.lims import TrackedSample, TrackedStudy
-from npg_irods.ont import find_recent_expt, find_recent_expt_slot
+from npg_irods.ont import Component, find_components_changed, find_recent_expt
 
 
 @m.describe("Finding updated ONT experiments by datetime")
@@ -62,50 +62,71 @@ class TestONTMLWarehouseQueries(object):
     @m.describe("Finding updated experiments and positions by datetime")
     @m.context("When a query date is provided")
     @m.it("Finds the correct experiment, slot tuples")
-    def test_find_recent_expt_pos(self, ont_synthetic_mlwh):
+    def test_find_recent_component(self, ont_synthetic_mlwh):
         before_late = LATE - timedelta(days=1)
         odd_expts = [
-            ("multiplexed_experiment_001", 1),
-            ("multiplexed_experiment_001", 2),
-            ("multiplexed_experiment_001", 3),
-            ("multiplexed_experiment_001", 4),
-            ("multiplexed_experiment_001", 5),
-            ("multiplexed_experiment_003", 1),
-            ("multiplexed_experiment_003", 2),
-            ("multiplexed_experiment_003", 3),
-            ("multiplexed_experiment_003", 4),
-            ("multiplexed_experiment_003", 5),
-            ("simple_experiment_001", 1),
-            ("simple_experiment_001", 2),
-            ("simple_experiment_001", 3),
-            ("simple_experiment_001", 4),
-            ("simple_experiment_001", 5),
-            ("simple_experiment_003", 1),
-            ("simple_experiment_003", 2),
-            ("simple_experiment_003", 3),
-            ("simple_experiment_003", 4),
-            ("simple_experiment_003", 5),
-            ("simple_experiment_005", 1),
-            ("simple_experiment_005", 2),
-            ("simple_experiment_005", 3),
-            ("simple_experiment_005", 4),
-            ("simple_experiment_005", 5),
+            Component(*args)
+            for args in [
+                ("multiplexed_experiment_001", 1),
+                ("multiplexed_experiment_001", 2),
+                ("multiplexed_experiment_001", 3),
+                ("multiplexed_experiment_001", 4),
+                ("multiplexed_experiment_001", 5),
+                ("multiplexed_experiment_003", 1),
+                ("multiplexed_experiment_003", 2),
+                ("multiplexed_experiment_003", 3),
+                ("multiplexed_experiment_003", 4),
+                ("multiplexed_experiment_003", 5),
+                ("simple_experiment_001", 1),
+                ("simple_experiment_001", 2),
+                ("simple_experiment_001", 3),
+                ("simple_experiment_001", 4),
+                ("simple_experiment_001", 5),
+                ("simple_experiment_003", 1),
+                ("simple_experiment_003", 2),
+                ("simple_experiment_003", 3),
+                ("simple_experiment_003", 4),
+                ("simple_experiment_003", 5),
+                ("simple_experiment_005", 1),
+                ("simple_experiment_005", 2),
+                ("simple_experiment_005", 3),
+                ("simple_experiment_005", 4),
+                ("simple_experiment_005", 5),
+            ]
         ]
-        assert find_recent_expt_slot(ont_synthetic_mlwh, before_late) == odd_expts
+        assert [
+            c
+            for c in find_components_changed(
+                ont_synthetic_mlwh, before_late, include_tags=False
+            )
+        ] == odd_expts
 
         before_latest = LATEST - timedelta(days=1)
         odd_positions = [
-            ("multiplexed_experiment_001", 1),
-            ("multiplexed_experiment_001", 3),
-            ("multiplexed_experiment_001", 5),
-            ("multiplexed_experiment_003", 1),
-            ("multiplexed_experiment_003", 3),
-            ("multiplexed_experiment_003", 5),
+            Component(*args)
+            for args in [
+                ("multiplexed_experiment_001", 1),
+                ("multiplexed_experiment_001", 3),
+                ("multiplexed_experiment_001", 5),
+                ("multiplexed_experiment_003", 1),
+                ("multiplexed_experiment_003", 3),
+                ("multiplexed_experiment_003", 5),
+            ]
         ]
-        assert find_recent_expt_slot(ont_synthetic_mlwh, before_latest) == odd_positions
+        assert [
+            c
+            for c in find_components_changed(
+                ont_synthetic_mlwh, before_latest, include_tags=False
+            )
+        ] == odd_positions
 
         after_latest = LATEST + timedelta(days=1)
-        assert find_recent_expt_slot(ont_synthetic_mlwh, after_latest) == []
+        assert [
+            c
+            for c in find_components_changed(
+                ont_synthetic_mlwh, after_latest, include_tags=False
+            )
+        ] == []
 
 
 @m.describe("Finding Illumina recently changed information in Illumina tables")


### PR DESCRIPTION
Refactor to separate initial ONT metadata creation from later regular updates, to introduce "component" data classes and DRY some repeated code.