### PR TITLE
Fix incorrect value for sample_id metadata

### DIFF
--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -90,7 +90,7 @@ def make_sample_metadata(sample: Sample) -> list[AVU]:
     Returns: List[AVU]
     """
     av = [
-        [TrackedSample.ID, sample.sanger_sample_id],
+        [TrackedSample.ID, sample.id_sample_lims],
         [TrackedSample.NAME, sample.name],
         [TrackedSample.ACCESSION_NUMBER, sample.accession_number],
         [TrackedSample.DONOR_ID, sample.donor_id],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,11 +196,20 @@ def initialize_mlwh_ont(session: Session):
 
     num_samples = 200
     for s in range(1, num_samples + 1):
-        sid = f"sample{s}"
+        lims_id = f"sample{s}"
         name = f"sample {s}"
+        donor_id = (f"donor {s}",)
+        accession = f"ACC{s}"
+        supplier_name = f"supplier_sample {s}"
         samples.append(
             Sample(
-                id_lims="LIMS_01", id_sample_lims=sid, name=name, **default_timestamps
+                accession_number=accession,
+                donor_id=donor_id,
+                id_lims="LIMS_01",
+                id_sample_lims=lims_id,
+                name=name,
+                supplier_name=supplier_name,
+                **default_timestamps,
             )
         )
     session.add_all(samples)

--- a/tests/test_ont.py
+++ b/tests/test_ont.py
@@ -42,7 +42,11 @@ class TestONT(object):
 
         coll = Collection(path)
         for avu in [
+            AVU(TrackedSample.ACCESSION_NUMBER, "ACC1"),
+            AVU(TrackedSample.DONOR_ID, "donor 1"),
+            AVU(TrackedSample.ID, "sample1"),
             AVU(TrackedSample.NAME, "sample 1"),
+            AVU(TrackedSample.SUPPLIER_NAME, "supplier_sample 1"),
             AVU(TrackedStudy.ID, "2000"),
             AVU(TrackedStudy.NAME, "Study Y"),
         ]:
@@ -93,7 +97,11 @@ class TestONT(object):
                 bc_coll = Collection(path / subcoll / ont.barcode_name_from_id(tag_id))
 
                 for avu in [
+                    AVU(TrackedSample.ACCESSION_NUMBER, f"ACC{tag_index}"),
+                    AVU(TrackedSample.DONOR_ID, f"donor {tag_index}"),
+                    AVU(TrackedSample.ID, f"sample{tag_index}"),
                     AVU(TrackedSample.NAME, f"sample {tag_index}"),
+                    AVU(TrackedSample.SUPPLIER_NAME, f"supplier_sample {tag_index}"),
                     AVU(TrackedStudy.ID, "3000"),
                     AVU(TrackedStudy.NAME, "Study Z"),
                 ]:


### PR DESCRIPTION
The value should be taken from the id_sample_lims column of the MLWH sample table, not the sanger_sample_id column.

This change adds a failing test, expands the tests to include all the sample metadat that is set and then fixes the failing test by correcting the error above.