### PR TITLE
Add sample_common_name and sample_public_name to iRODS sample metadata

### DIFF
--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -78,12 +78,14 @@ class TrackedStudy(AsValueEnum):
 def make_sample_metadata(sample: Sample) -> list[AVU]:
     """Return standard iRODS metadata for a Sample:
 
+     - sample accession
+     - sample common name
+     - sample consent withdrawn
+     - sample donor ID
      - sample ID
      - sample name
-     - sample accession
-     - sample donor ID
+     - sample public name
      - sample supplier name
-     - sample consent withdrawn
 
     Args:
         sample: An ML warehouse schema Sample.
@@ -92,15 +94,17 @@ def make_sample_metadata(sample: Sample) -> list[AVU]:
         AVUs
     """
     av = [
-        [TrackedSample.ID, sample.id_sample_lims],
-        [TrackedSample.NAME, sample.name],
         [TrackedSample.ACCESSION_NUMBER, sample.accession_number],
-        [TrackedSample.DONOR_ID, sample.donor_id],
-        [TrackedSample.SUPPLIER_NAME, sample.supplier_name],
+        [TrackedSample.COMMON_NAME, sample.common_name],
         [
             TrackedSample.CONSENT_WITHDRAWN,
             1 if sample.consent_withdrawn else None,
         ],
+        [TrackedSample.DONOR_ID, sample.donor_id],
+        [TrackedSample.ID, sample.id_sample_lims],
+        [TrackedSample.NAME, sample.name],
+        [TrackedSample.PUBLIC_NAME, sample.public_name],
+        [TrackedSample.SUPPLIER_NAME, sample.supplier_name],
     ]
 
     return list(filter(lambda avu: avu is not None, starmap(avu_if_value, av)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,18 +227,22 @@ def initialize_mlwh_ont_synthetic(session: Session):
 
     num_samples = 200
     for s in range(1, num_samples + 1):
-        lims_id = f"sample{s}"
-        name = f"sample {s}"
-        donor_id = (f"donor {s}",)
         accession = f"ACC{s}"
-        supplier_name = f"supplier_sample {s}"
+        common_name = f"common_name{s}"
+        donor_id = f"donor_id{s}"
+        id_sample_lims = f"id_sample_lims{s}"
+        name = f"name{s}"
+        public_name = f"public_name{s}"
+        supplier_name = f"supplier_name{s}"
         samples.append(
             Sample(
                 accession_number=accession,
+                common_name=common_name,
                 donor_id=donor_id,
                 id_lims="LIMS_01",
-                id_sample_lims=lims_id,
+                id_sample_lims=id_sample_lims,
                 name=name,
+                public_name=public_name,
                 supplier_name=supplier_name,
                 **default_timestamps,
             )
@@ -358,28 +362,34 @@ def initialize_mlwh_illumina_synthetic(session: Session):
     session.flush()
 
     sample1 = Sample(
-        donor_id="donor1",
+        common_name="common_name1",
+        donor_id="donor_id1",
         id_lims="LIMS_01",
-        id_sample_lims="sample1",
-        name="sample 1",
+        id_sample_lims="id_sample_lims1",
+        name="name1",
+        public_name="public_name1",
         sanger_sample_id="sanger_sample1",
         supplier_name="supplier_name1",
         **default_timestamps,
     )
     sample2 = Sample(
-        donor_id="donor2",
+        common_name="common_name2",
+        donor_id="donor_id2",
         id_lims="LIMS_01",
-        id_sample_lims="sample2",
-        name="sample 2",
+        id_sample_lims="id_sample_lims2",
+        name="name2",
+        public_name="public_name2",
         sanger_sample_id="sanger_sample2",
         supplier_name="supplier_name2",
         **default_timestamps,
     )
     sample3 = Sample(
-        donor_id="donor3",
+        common_name="common_name3",
+        donor_id="donor_id3",
         id_lims="LIMS_01",
-        id_sample_lims="sample3",
-        name="sample 3",
+        id_sample_lims="id_samplelims3",
+        name="name3",
+        public_name="public_name3",
         sanger_sample_id="sanger_sample3",
         supplier_name="supplier_name3",
         **default_timestamps,

--- a/tests/test_illumina.py
+++ b/tests/test_illumina.py
@@ -36,12 +36,14 @@ class TestIlluminaMetadataUpdate(object):
         path = illumina_synthetic_irods / "12345/12345.cram"
         obj = DataObject(path)
         expected_avus = [
+            AVU(TrackedSample.COMMON_NAME, "common_name1"),
+            AVU(TrackedSample.DONOR_ID, "donor_id1"),
+            AVU(TrackedSample.ID, "id_sample_lims1"),
+            AVU(TrackedSample.NAME, "name1"),
+            AVU(TrackedSample.PUBLIC_NAME, "public_name1"),
+            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
             AVU(TrackedStudy.ID, "4000"),
             AVU(TrackedStudy.NAME, "Study A"),
-            AVU(TrackedSample.DONOR_ID, "donor1"),
-            AVU(TrackedSample.ID, "sample1"),
-            AVU(TrackedSample.NAME, "sample 1"),
-            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
         ]
 
         for avu in expected_avus:
@@ -64,12 +66,14 @@ class TestIlluminaMetadataUpdate(object):
         zone = "testZone"
         obj = DataObject(path)
         expected_avus = [
+            AVU(TrackedSample.COMMON_NAME, "common_name1"),
+            AVU(TrackedSample.DONOR_ID, "donor_id1"),
+            AVU(TrackedSample.ID, "id_sample_lims1"),
+            AVU(TrackedSample.NAME, "name1"),
+            AVU(TrackedSample.PUBLIC_NAME, "public_name1"),
+            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
             AVU(TrackedStudy.ID, "4000"),
             AVU(TrackedStudy.NAME, "Study A"),
-            AVU(TrackedSample.DONOR_ID, "donor1"),
-            AVU(TrackedSample.ID, "sample1"),
-            AVU(TrackedSample.NAME, "sample 1"),
-            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
         ]
         obj.add_metadata(*expected_avus)
 
@@ -101,12 +105,12 @@ class TestIlluminaMetadataUpdate(object):
             assert avu in obj.metadata()
 
         expected_avus = [
+            AVU(TrackedSample.DONOR_ID, "donor_id1"),
+            AVU(TrackedSample.ID, "id_sample_lims1"),
+            AVU(TrackedSample.NAME, "name1"),
+            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
             AVU(TrackedStudy.ID, "4000"),
             AVU(TrackedStudy.NAME, "Study A"),
-            AVU(TrackedSample.DONOR_ID, "donor1"),
-            AVU(TrackedSample.ID, "sample1"),
-            AVU(TrackedSample.NAME, "sample 1"),
-            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
         ]
 
         assert ensure_secondary_metadata_updated(
@@ -158,12 +162,14 @@ class TestIlluminaMetadataUpdate(object):
         path = illumina_synthetic_irods / "12345/12345#1.cram"
         obj = DataObject(path)
         expected_avus = [
+            AVU(TrackedSample.COMMON_NAME, "common_name1"),
+            AVU(TrackedSample.DONOR_ID, "donor_id1"),
+            AVU(TrackedSample.ID, "id_sample_lims1"),
+            AVU(TrackedSample.NAME, "name1"),
+            AVU(TrackedSample.PUBLIC_NAME, "public_name1"),
+            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
             AVU(TrackedStudy.ID, "4000"),
             AVU(TrackedStudy.NAME, "Study A"),
-            AVU(TrackedSample.DONOR_ID, "donor1"),
-            AVU(TrackedSample.ID, "sample1"),
-            AVU(TrackedSample.NAME, "sample 1"),
-            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
         ]
 
         for avu in expected_avus:
@@ -204,16 +210,20 @@ class TestIlluminaMetadataUpdate(object):
         path = illumina_synthetic_irods / "12345/12345#0.cram"
         obj = DataObject(path)
         expected_avus = [
-            AVU(TrackedStudy.ID, "4000"),
-            AVU(TrackedStudy.NAME, "Study A"),
-            AVU(TrackedSample.DONOR_ID, "donor1"),
-            AVU(TrackedSample.DONOR_ID, "donor2"),
-            AVU(TrackedSample.ID, "sample1"),
-            AVU(TrackedSample.ID, "sample2"),
-            AVU(TrackedSample.NAME, "sample 1"),
-            AVU(TrackedSample.NAME, "sample 2"),
+            AVU(TrackedSample.COMMON_NAME, "common_name1"),
+            AVU(TrackedSample.COMMON_NAME, "common_name2"),
+            AVU(TrackedSample.DONOR_ID, "donor_id1"),
+            AVU(TrackedSample.DONOR_ID, "donor_id2"),
+            AVU(TrackedSample.ID, "id_sample_lims1"),
+            AVU(TrackedSample.ID, "id_sample_lims2"),
+            AVU(TrackedSample.NAME, "name1"),
+            AVU(TrackedSample.NAME, "name2"),
+            AVU(TrackedSample.PUBLIC_NAME, "public_name1"),
+            AVU(TrackedSample.PUBLIC_NAME, "public_name2"),
             AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
             AVU(TrackedSample.SUPPLIER_NAME, "supplier_name2"),
+            AVU(TrackedStudy.ID, "4000"),
+            AVU(TrackedStudy.NAME, "Study A"),
         ]
 
         for avu in expected_avus:
@@ -236,19 +246,23 @@ class TestIlluminaMetadataUpdate(object):
         path = illumina_synthetic_irods / "12345/12345#0.cram"
         obj = DataObject(path)
         expected_avus = [
+            AVU(TrackedSample.COMMON_NAME, "common_name1"),
+            AVU(TrackedSample.COMMON_NAME, "common_name2"),
+            AVU(TrackedSample.DONOR_ID, "donor_id1"),
+            AVU(TrackedSample.DONOR_ID, "donor_id2"),
+            AVU(TrackedSample.ID, "id_sample_lims1"),
+            AVU(TrackedSample.ID, "id_sample_lims2"),
+            AVU(TrackedSample.NAME, "name1"),
+            AVU(TrackedSample.NAME, "name2"),
+            AVU(TrackedSample.NAME, "Phi X"),
+            AVU(TrackedSample.PUBLIC_NAME, "public_name1"),
+            AVU(TrackedSample.PUBLIC_NAME, "public_name2"),
+            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
+            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name2"),
             AVU(TrackedStudy.ID, "4000"),
             AVU(TrackedStudy.ID, "888"),
             AVU(TrackedStudy.NAME, "Study A"),
             AVU(TrackedStudy.NAME, "Control Study"),
-            AVU(TrackedSample.DONOR_ID, "donor1"),
-            AVU(TrackedSample.DONOR_ID, "donor2"),
-            AVU(TrackedSample.ID, "sample1"),
-            AVU(TrackedSample.ID, "sample2"),
-            AVU(TrackedSample.NAME, "sample 1"),
-            AVU(TrackedSample.NAME, "sample 2"),
-            AVU(TrackedSample.NAME, "Phi X"),
-            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
-            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name2"),
         ]
 
         for avu in expected_avus:
@@ -293,12 +307,14 @@ class TestIlluminaPermissionsUpdate:
         obj = DataObject(path)
 
         expected_metadata = [
+            AVU(TrackedSample.COMMON_NAME, "common_name1"),
+            AVU(TrackedSample.DONOR_ID, "donor_id1"),
+            AVU(TrackedSample.ID, "id_sample_lims1"),
+            AVU(TrackedSample.NAME, "name1"),
+            AVU(TrackedSample.PUBLIC_NAME, "public_name1"),
+            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
             AVU(TrackedStudy.ID, "4000"),
             AVU(TrackedStudy.NAME, "Study A"),
-            AVU(TrackedSample.DONOR_ID, "donor1"),
-            AVU(TrackedSample.ID, "sample1"),
-            AVU(TrackedSample.NAME, "sample 1"),
-            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
         ]
         obj.add_metadata(*expected_metadata)
 

--- a/tests/test_ont.py
+++ b/tests/test_ont.py
@@ -51,10 +51,12 @@ class TestONTMetadataCreation(object):
         coll = Collection(path)
         for avu in [
             AVU(TrackedSample.ACCESSION_NUMBER, "ACC1"),
-            AVU(TrackedSample.DONOR_ID, "donor 1"),
-            AVU(TrackedSample.ID, "sample1"),
-            AVU(TrackedSample.NAME, "sample 1"),
-            AVU(TrackedSample.SUPPLIER_NAME, "supplier_sample 1"),
+            AVU(TrackedSample.COMMON_NAME, "common_name1"),
+            AVU(TrackedSample.DONOR_ID, "donor_id1"),
+            AVU(TrackedSample.ID, "id_sample_lims1"),
+            AVU(TrackedSample.NAME, "name1"),
+            AVU(TrackedSample.SUPPLIER_NAME, "supplier_name1"),
+            AVU(TrackedSample.PUBLIC_NAME, "public_name1"),
             AVU(TrackedStudy.ID, "2000"),
             AVU(TrackedStudy.NAME, "Study Y"),
         ]:
@@ -107,10 +109,12 @@ class TestONTMetadataCreation(object):
 
                 for avu in [
                     AVU(TrackedSample.ACCESSION_NUMBER, f"ACC{tag_index}"),
-                    AVU(TrackedSample.DONOR_ID, f"donor {tag_index}"),
-                    AVU(TrackedSample.ID, f"sample{tag_index}"),
-                    AVU(TrackedSample.NAME, f"sample {tag_index}"),
-                    AVU(TrackedSample.SUPPLIER_NAME, f"supplier_sample {tag_index}"),
+                    AVU(TrackedSample.COMMON_NAME, f"common_name{tag_index}"),
+                    AVU(TrackedSample.DONOR_ID, f"donor_id{tag_index}"),
+                    AVU(TrackedSample.ID, f"id_sample_lims{tag_index}"),
+                    AVU(TrackedSample.NAME, f"name{tag_index}"),
+                    AVU(TrackedSample.PUBLIC_NAME, f"public_name{tag_index}"),
+                    AVU(TrackedSample.SUPPLIER_NAME, f"supplier_name{tag_index}"),
                     AVU(TrackedStudy.ID, "3000"),
                     AVU(TrackedStudy.NAME, "Study Z"),
                 ]:
@@ -257,7 +261,7 @@ class TestONTMetadataUpdate(object):
             ont_synthetic_irods
             / "simple_experiment_001/20190904_1514_G100000_flowcell011_69126024"
         )
-        assert AVU(TrackedSample.NAME, "sample 1") not in coll.metadata()
+        assert AVU(TrackedSample.NAME, "name1") not in coll.metadata()
 
         update_metadata(
             experiment_name="simple_experiment_001",
@@ -265,7 +269,7 @@ class TestONTMetadataUpdate(object):
             mlwh_session=ont_synthetic_mlwh,
         )
 
-        assert AVU(TrackedSample.NAME, "sample 1") in coll.metadata()
+        assert AVU(TrackedSample.NAME, "name1") in coll.metadata()
 
     @m.context("When correct metadata is already present")
     @m.it("Leaves the metadata unchanged")
@@ -274,7 +278,7 @@ class TestONTMetadataUpdate(object):
             ont_synthetic_irods
             / "simple_experiment_001/20190904_1514_G100000_flowcell011_69126024"
         )
-        coll.add_metadata(AVU(TrackedSample.NAME, "sample 1"))
+        coll.add_metadata(AVU(TrackedSample.NAME, "name1"))
 
         update_metadata(
             experiment_name="simple_experiment_001",
@@ -282,7 +286,7 @@ class TestONTMetadataUpdate(object):
             mlwh_session=ont_synthetic_mlwh,
         )
 
-        assert AVU(TrackedSample.NAME, "sample 1") in coll.metadata()
+        assert AVU(TrackedSample.NAME, "name1") in coll.metadata()
 
     @m.context("When incorrect metadata is present")
     @m.it("Changes the metadata and adds history metadata")
@@ -291,7 +295,7 @@ class TestONTMetadataUpdate(object):
             ont_synthetic_irods
             / "simple_experiment_001/20190904_1514_G100000_flowcell011_69126024"
         )
-        coll.add_metadata(AVU(TrackedSample.NAME, "sample 0"))
+        coll.add_metadata(AVU(TrackedSample.NAME, "name0"))
 
         update_metadata(
             experiment_name="simple_experiment_001",
@@ -299,10 +303,10 @@ class TestONTMetadataUpdate(object):
             mlwh_session=ont_synthetic_mlwh,
         )
 
-        assert AVU(TrackedSample.NAME, "sample 1") in coll.metadata()
-        assert AVU(TrackedSample.NAME, "sample 0") not in coll.metadata()
+        assert AVU(TrackedSample.NAME, "name1") in coll.metadata()
+        assert AVU(TrackedSample.NAME, "name0") not in coll.metadata()
         assert history_in_meta(
-            AVU.history(AVU(TrackedSample.NAME, "sample 0")), coll.metadata()
+            AVU.history(AVU(TrackedSample.NAME, "name0")), coll.metadata()
         )
 
     @m.context("When an attribute has multiple incorrect values")


### PR DESCRIPTION
Add these to the function that generates sample metadata.

Rationalise the metadata dummy values used in tests to be more transparent about their source.

Sort metadata consistently in tests (alphabetical, study metadata last)