### PR TITLE
Fix Dockerfile for change to pyproject.toml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,6 @@
 .pytest_cache
 Dockerfile
 dist
-LICENSE
-README.md
 docker-compose.yml
 pytest.ini
 *.report.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selectio
     git \
     libtool \
     pkg-config \
+    libffi-dev \
     libbz2-dev \
     libssl-dev \
     zlib1g-dev \


### PR DESCRIPTION
Install libffi-dev on the build host before building Python with pyenv, otherwise the build eventually errors with "ImportError: No module named '_ctypes'". This was not required when using setup.py.

Don't exclude files referred to in pyproject.toml from the Docker build.