### PR TITLE
Avoid creating a dirty build environment in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,6 @@
 .DS_Store
-.dockerignore
-.github
-.gitignore
 .pytest_cache
-Dockerfile
+build
 dist
-docker-compose.yml
-pytest.ini
+*.egg-info
 *.report.json

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ profile_default/
 ipython_config.py
 
 # pyenv
+.pyenv
 .python-version
 
 # pipenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,12 @@ WORKDIR /app
 
 COPY --from=builder /app /app
 
-# Mount the .git directory to allow setuptools_scm to get the version
+# Mount the .git directory to allow the build to get the version from git
 RUN --mount=source=.git,target=.git,type=bind \
     pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir .
+    pip install --no-cache-dir . && \
+    git status && \
+    ls -al
 
 RUN useradd -l -m -s /bin/false appuser && mkdir /home/appuser/.irods
 

--- a/docker/install_pyenv.sh
+++ b/docker/install_pyenv.sh
@@ -8,5 +8,8 @@ export PYENV_GIT_TAG="v${PYENV_RELEASE_VERSION}"
 PYENV_ROOT=${PYENV_ROOT:-"$HOME/.pyenv"}
 export PATH="$PYENV_ROOT/bin:$PATH"
 
+PYENV_SHA256="a1ad63c22842dce498b441551e2f83ede3e3b6ebb33f62013607bba424683191"
 curl -sSL -O https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer
+sha256sum ./pyenv-installer | grep "$PYENV_SHA256"
 /bin/bash ./pyenv-installer
+rm ./pyenv-installer


### PR DESCRIPTION
Build versions are getting tagged dirty by git describe. The main culprit is the .dockerignore file which excludes some git-tracked files from the build. This change removes the exclusions.

An additional cause was the local pyenv installation (both the installer script and install itself) which are now ignored or removed prior to the build.