### PR TITLE
Use `exception` rather than `error` method for Exception logging

### DIFF
--- a/scripts/locate-data-objects
+++ b/scripts/locate-data-objects
@@ -132,7 +132,7 @@ def consent_withdrawn(cli_args):
                     print(obj)
             except Exception as e:
                 num_errors += 1
-                log.error(e, item=i, sample=s)
+                log.exception(e, item=i, sample=s)
 
     log.info(f"Processed {num_processed} with {num_errors} errors")
     if num_errors:
@@ -224,7 +224,7 @@ def illumina_updates(cli_args):
 
             except Exception as e:
                 num_errors += 1
-                log.error(e, item=i, component=c)
+                log.exception(e, item=i, component=c)
 
         log.info(f"Processed {num_processed} with {num_errors} errors")
         if num_errors:
@@ -280,7 +280,7 @@ def ont_updates(cli_args):
 
             except Exception as e:
                 num_errors += 1
-                log.error(e, item=i, component=c)
+                log.exception(e, item=i, component=c)
 
         log.info(f"Processed {num_processed} with {num_errors} errors")
         if num_errors:

--- a/src/npg_irods/cli.py
+++ b/src/npg_irods/cli.py
@@ -149,6 +149,7 @@ def configure_logging(
         # sys.exc_info() tuple, remove "exc_info" and render the exception
         # with traceback into the "exception" key.
         structlog.processors.format_exc_info,
+        # structlog.processors.dict_tracebacks,
         # If some value is in bytes, decode it to a unicode str.
         structlog.processors.UnicodeDecoder(),
         # Add call site parameters.

--- a/src/npg_irods/utilities.py
+++ b/src/npg_irods/utilities.py
@@ -143,7 +143,7 @@ def check_checksums(
                 if print_fail:
                     _print(p, writer)
             except Exception as e:
-                log.error(e)
+                log.exception(e)
                 if print_fail:
                     _print(p, writer)
 
@@ -234,7 +234,7 @@ def repair_checksums(
                 if print_fail:
                     _print(p, writer)
             except Exception as e:
-                log.error(e, item=i)
+                log.exception(e, item=i)
                 if print_fail:
                     _print(p, writer)
 
@@ -321,7 +321,7 @@ def check_replicas(
                 if print_fail:
                     _print(p, writer)
             except Exception as e:
-                log.error(e, item=i)
+                log.exception(e, item=i)
                 if print_fail:
                     _print(p, writer)
 
@@ -423,7 +423,7 @@ def repair_replicas(
                 if print_fail:
                     _print(p, writer)
             except Exception as e:
-                log.error(e, item=i)
+                log.exception(e, item=i)
                 if print_fail:
                     _print(p, writer)
 
@@ -491,7 +491,7 @@ def check_common_metadata(
                 if print_fail:
                     _print(p, writer)
             except Exception as e:
-                log.error(e, item=i)
+                log.exception(e, item=i)
                 if print_fail:
                     _print(p, writer)
 
@@ -573,7 +573,7 @@ def repair_common_metadata(
                 if print_fail:
                     _print(p, writer)
             except Exception as e:
-                log.error(e, item=i)
+                log.exception(e, item=i)
                 if print_fail:
                     _print(p, writer)
 
@@ -652,7 +652,7 @@ def update_secondary_metadata(
                 _print(path, writer)
         except Exception as e:
             num_errors += 1
-            log.error(e, item=i)
+            log.exception(e, item=i)
             if print_fail:
                 _print(path, writer)
 
@@ -713,7 +713,7 @@ def check_consent_withdrawn(
             if print_fail:
                 _print(p, writer)
         except Exception as e:
-            log.error(e, item=i)
+            log.exception(e, item=i)
             num_errors += 1
             if print_fail:
                 _print(p, writer)
@@ -770,7 +770,7 @@ def withdraw_consent(
             if print_fail:
                 _print(p, writer)
         except Exception as e:
-            log.error(e, item=i)
+            log.exception(e, item=i)
             num_errors += 1
             if print_fail:
                 _print(p, writer)


### PR DESCRIPTION
When handling a non-specific Exception for logging, use the `exception` method to get more detailed information about the cause.