### PR TITLE
Bug fix and improvements for ONT metadata updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==41.0.2
 npg_id_generation@https://github.com/wtsi-npg/npg_id_generation/releases/download/3.0.0/npg_id_generation-3.0.0.tar.gz
-partisan@https://github.com/wtsi-npg/partisan/releases/download/2.5.1/partisan-2.5.1.tar.gz
+partisan@https://github.com/wtsi-npg/partisan/releases/download/2.6.0/partisan-2.6.0.tar.gz
 pymysql==1.1.0
 rich==13.4.2
 setuptools==68.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==41.0.2
 npg_id_generation@https://github.com/wtsi-npg/npg_id_generation/releases/download/3.0.0/npg_id_generation-3.0.0.tar.gz
-partisan@https://github.com/wtsi-npg/partisan/releases/download/2.6.0/partisan-2.6.0.tar.gz
+partisan@https://github.com/wtsi-npg/partisan/releases/download/2.7.0/partisan-2.7.0.tar.gz
 pymysql==1.1.0
 rich==13.4.2
 setuptools==68.0.0

--- a/scripts/locate-data-objects
+++ b/scripts/locate-data-objects
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta, timezone
 
 import sqlalchemy
 import structlog
-from partisan.irods import AVU, Collection, query_metadata
+from partisan.irods import AVU, query_metadata
 from sqlalchemy.orm import Session
 
 from npg_irods import illumina, ont
@@ -39,7 +39,7 @@ from npg_irods.db.mlwh import find_consent_withdrawn_samples
 from npg_irods.metadata.common import SeqConcept
 from npg_irods.metadata.illumina import Instrument
 from npg_irods.metadata.lims import TrackedSample
-from npg_irods.ont import barcode_collections, barcode_name_from_id
+from npg_irods.ont import barcode_collections
 from npg_irods.version import version
 
 description = """

--- a/scripts/locate-data-objects
+++ b/scripts/locate-data-objects
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta, timezone
 
 import sqlalchemy
 import structlog
-from partisan.irods import AVU, query_metadata
+from partisan.irods import AVU, Collection, query_metadata
 from sqlalchemy.orm import Session
 
 from npg_irods import illumina, ont
@@ -39,6 +39,7 @@ from npg_irods.db.mlwh import find_consent_withdrawn_samples
 from npg_irods.metadata.common import SeqConcept
 from npg_irods.metadata.illumina import Instrument
 from npg_irods.metadata.lims import TrackedSample
+from npg_irods.ont import barcode_collections, barcode_name_from_id
 from npg_irods.version import version
 
 description = """
@@ -68,7 +69,7 @@ Examples:
     locate-data-objects --verbose --json  --database-config db.ini --zone seq \\
         illumina-updates --begin-date `date --iso --date=-7day` \\
         --skip-absent-runs
-    
+
     locate-data-objects --verbose --colour --database-config db.ini --zone seq \\
         ont-updates --begin-date `date --iso --date=-7day`
 
@@ -81,7 +82,12 @@ schema = <database schema name>
 user = <database user name>
 password = <database password>
 
-The paths of the data objects located are printed to STDOUT.
+The paths of the data objects and/or collections located are printed to STDOUT.
+Whether data objects or collection paths are printed depends on which of these
+the matched iRODS metadata are attached to. If the metadata are directly attached
+to a data object, its path is printed, while if the metadata are attached to a
+collection containing a data object, directly or as a root collection, the
+collection path is printed.
 """
 
 parser = argparse.ArgumentParser(
@@ -236,17 +242,23 @@ ilup_parser.set_defaults(func=illumina_updates)
 
 ontup_parser = subparsers.add_parser(
     "ont-updates",
-    help="Find data objects, which are components of ONT runs, whose tracking metadata "
-    "in the ML warehouse have changed since a specified time.",
+    help="Find collections, containing data objects for ONT runs, whose tracking"
+    "metadata in the ML warehouse have changed since a specified time.",
 )
 ontup_parser.add_argument(
     "--begin-date",
     "--begin_date",
-    help="Limit data objects found to those changed after this date. Defaults to 14 "
+    help="Limit collections found to those changed after this date. Defaults to 14 "
     "days ago. The argument must be an ISO8601 UTC date or date and time e.g. "
     "2022-01-30, 2022-01-30T11:11:03Z",
     type=parse_iso_date,
     default=datetime.now(timezone.utc) - timedelta(days=14),
+)
+ontup_parser.add_argument(
+    "--report-tags",
+    "--report_tags",
+    help="Include barcode sub-collections of runs containing de-multiplexed data.",
+    action="store_true",
 )
 
 
@@ -256,10 +268,11 @@ def ont_updates(cli_args):
     with Session(engine) as session:
         num_processed = num_errors = 0
         iso_date = cli_args.begin_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        report_tags = cli_args.report_tags
 
         for i, c in enumerate(
             ont.find_components_changed(
-                session, include_tags=False, since=cli_args.begin_date
+                session, include_tags=report_tags, since=cli_args.begin_date
             )
         ):
             num_processed += 1
@@ -270,13 +283,16 @@ def ont_updates(cli_args):
                     AVU(ont.Instrument.EXPERIMENT_NAME, c.experiment_name),
                     AVU(ont.Instrument.INSTRUMENT_SLOT, c.instrument_slot),
                 ]
-                if c.tag_identifier is not None:
-                    avus.append(AVU(ont.Instrument.TAG_IDENTIFIER, c.tag_identifier))
-
                 for coll in query_metadata(
                     *avus, data_object=False, zone=cli_args.zone
                 ):
-                    print(coll)
+                    # Report only the run folder collection for multiplexed runs
+                    # unless requested to report the deplexed collections
+                    if report_tags and c.tag_identifier is not None:
+                        for bcoll in barcode_collections(coll, c.tag_identifier):
+                            print(bcoll)
+                    else:
+                        print(coll)
 
             except Exception as e:
                 num_errors += 1

--- a/src/npg_irods/common.py
+++ b/src/npg_irods/common.py
@@ -213,6 +213,8 @@ def update_metadata(item: Collection | DataObject, avus: list[AVU]) -> bool:
         True if any changes were made, False if the desired metadata were already
         present.
     """
+    avus = sorted(set(avus))  # Ensure no duplicates, sort for reproducibility
+
     log.info("Updating metadata", path=item, meta=avus)
     num_removed, num_added = item.supersede_metadata(*avus, history=True)
     log.info(
@@ -247,6 +249,8 @@ def update_permissions(
         raise ValueError(
             f"Cannot recursively update permissions on a data object: {item}"
         )
+
+    acl = sorted(set(acl))  # Ensure no duplicates, sort for reproducibility
 
     if has_mixed_ownership(acl):
         log.warn("Mixed-study data", path=item, acl=acl)

--- a/src/npg_irods/illumina.py
+++ b/src/npg_irods/illumina.py
@@ -194,8 +194,7 @@ def ensure_secondary_metadata_updated(
     secondary_metadata, acl = [], []
 
     components = [
-        Component.from_avu(avu)
-        for avu in item.metadata(attr=SeqConcept.COMPONENT.value)
+        Component.from_avu(avu) for avu in item.metadata(SeqConcept.COMPONENT)
     ]  # Illumina specific
     for c in components:
         for fc in find_flowcells_by_component(

--- a/src/npg_irods/metadata/common.py
+++ b/src/npg_irods/metadata/common.py
@@ -203,7 +203,7 @@ def has_matching_checksum_metadata(obj: DataObject) -> bool:
     # It's possible, technically, for there to be multiple checksum AVUs in an
     # object's metadata because iRODS is permissive on this. If we find more than
     # one, we consider that the checksum metadata do not match.
-    checksum_meta = obj.metadata(DataFile.MD5.value)
+    checksum_meta = obj.metadata(DataFile.MD5)
     if len(checksum_meta) > 1:
         return False
 
@@ -269,9 +269,7 @@ def ensure_matching_checksum_metadata(obj: DataObject) -> bool:
         return True
 
     expected_avu = AVU(DataFile.MD5, obj.checksum())
-    observed_avus = [
-        avu for avu in obj.metadata() if avu.attribute == DataFile.MD5.value
-    ]
+    observed_avus = obj.metadata(DataFile.MD5)
 
     num_added, num_removed = obj.supersede_metadata(expected_avu, history=True)
     if num_added and expected_avu in obj.metadata():
@@ -497,7 +495,7 @@ def has_checksum_metadata(obj: DataObject) -> bool:
     Returns:
         True if the metadata are present, or False otherwise.
     """
-    return len(obj.metadata(DataFile.MD5.value)) > 0
+    return len(obj.metadata(DataFile.MD5)) > 0
 
 
 def make_checksum_metadata(checksum: str) -> list[AVU]:
@@ -555,7 +553,7 @@ def has_type_metadata(obj: DataObject) -> bool:
     Returns:
         True if the metadata are present, or False otherwise.
     """
-    return len(obj.metadata(DataFile.TYPE.value)) > 0
+    return len(obj.metadata(DataFile.TYPE)) > 0
 
 
 def make_type_metadata(obj: DataObject) -> list[AVU]:

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -421,4 +421,4 @@ def has_id_product_metadata(obj: DataObject):
     Returns:
         True if the object has id product metadata, False otherwise.
     """
-    return len(obj.metadata(SeqConcept.ID_PRODUCT.value)) > 0
+    return len(obj.metadata(SeqConcept.ID_PRODUCT)) > 0

--- a/src/npg_irods/metadata/ont.py
+++ b/src/npg_irods/metadata/ont.py
@@ -26,8 +26,17 @@ from partisan.metadata import AsValueEnum, with_namespace
 class Instrument(AsValueEnum, metaclass=with_namespace("ont")):
     """Oxford Nanopore platform metadata"""
 
+    DEVICE_ID = "device_id"
+    DEVICE_TYPE = "device_type"
+    DISTRIBUTION_VERSION = "distribution_version"
     EXPERIMENT_NAME = "experiment_name"
+    FLOWCELL_ID = "flowcell_id"
+    GUPPY_VERSION = "guppy_version"
+    HOSTNAME = "hostname"
     INSTRUMENT_SLOT = "instrument_slot"
+    PROTOCOL_GROUP_ID = "protocol_group_id"
+    RUN_ID = "run_id"
+    SAMPLE_ID = "sample_id"
     TAG_IDENTIFIER = "tag_identifier"
 
     def __repr__(self):

--- a/src/npg_irods/mlwh_locations/illumina.py
+++ b/src/npg_irods/mlwh_locations/illumina.py
@@ -83,7 +83,7 @@ def has_phix_reference(obj: DataObject) -> bool:
     Returns: bool
     """
     for meta in obj.metadata():
-        if meta.attribute == str(SeqConcept.REFERENCE) and "PhiX" in meta.value:
+        if meta.attribute == SeqConcept.REFERENCE.value and "PhiX" in meta.value:
             return True
 
     return False
@@ -102,7 +102,7 @@ def has_subset(obj: DataObject) -> bool:
     """
     for meta in obj.metadata():
         # subset is not present alone, but is part of the component metadata
-        if meta.attribute == str(SeqConcept.COMPONENT) and "subset" in meta.value:
+        if meta.attribute == SeqConcept.COMPONENT.value and "subset" in meta.value:
             return True
 
     return False


### PR DESCRIPTION
Fix a bug in ont.ensure_secondary_metadata_updated where the ONT
metadata namespace was not used when querying iRODS, so no collections
were found.

Add the ability for locate-data-objects to print ONT barcode
sub-collections.

Improve the SQL query used in ont.find_recent_expt to better handle
multiplexed runs (those having i.e. those having non-NULL tag
identifiers).

Add more metadata to the ONT instrument enum.

Bump partisan dependency from 2.5.1 to 2.6.0 to access better handling
of namespaced attributes. Take advantage of this for creating some
AVUs by avoiding the need to explicitly refer to the "value" property
of some enum members.