### PR TITLE
Fix accidental expansion of ACL groups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==41.0.3
 npg_id_generation@https://github.com/wtsi-npg/npg_id_generation/releases/download/3.0.0/npg_id_generation-3.0.0.tar.gz
-partisan@https://github.com/wtsi-npg/partisan/releases/download/2.7.0/partisan-2.7.0.tar.gz
+partisan@https://github.com/wtsi-npg/partisan/releases/download/2.8.1/partisan-2.8.1.tar.gz
 pymysql==1.1.0
 rich==13.5.2
 setuptools==68.2.2


### PR DESCRIPTION
When updating permissions, any iRODS group was being expanded into its member iRODS users and those user permissions were also being set.

This is a side-effect of the way iRODS reports permissions and can be worked around by filtering the ACLs to remove unwanted types of permission. The filtering API has been added to partisan in 2.8.1, which is now updated in requirements.