### PR TITLE
Update test matrix iRODS versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,20 +18,21 @@ jobs:
     strategy:
       matrix:
         include:
-          # iRODS 4.2.11 clients vs 4.2.7 server
-          - irods: "4.2.11"
-            client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.11:latest"
+          - irods: "4.2.7"
+            client_image: "ghcr.io/wtsi-npg/ub-16.04-irods-clients-4.2.7:latest"
             server_image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
             experimental: false
-          # iRODS 4.2.11 clients vs 4.2.11 server
           - irods: "4.2.11"
             client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.11:latest"
             server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.11:latest"
             experimental: false
-          # iRODS 4.2.12 clients vs 4.2.12 server
           - irods: "4.2.12"
             client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.12:latest"
             server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.12:latest"
+            experimental: false
+          - irods: "4.3.0"
+            client_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-4.3-nightly:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3-nightly:latest"
             experimental: true
 
     services:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==41.0.4
 npg_id_generation@https://github.com/wtsi-npg/npg_id_generation/releases/download/3.0.0/npg_id_generation-3.0.0.tar.gz
-partisan@https://github.com/wtsi-npg/partisan/releases/download/2.8.1/partisan-2.8.1.tar.gz
+partisan@https://github.com/wtsi-npg/partisan/releases/download/2.9.0/partisan-2.9.0.tar.gz
 pymysql==1.1.0
 rich==13.6.0
 setuptools==68.2.2


### PR DESCRIPTION
Remove the combination of 4.2.11 clients with a 4.2.7 server

Add the combination of 4.2.7 clients with a 4.2.7 server Add the combination of 4.3-nightly clients with a 4.3-nightly server

Bump partisan from 2.8.1 to 2.9.0