### PR TITLE
Avoid raising exceptions when processing control CRAM files

### DIFF
--- a/src/npg_irods/utilities.py
+++ b/src/npg_irods/utilities.py
@@ -625,7 +625,7 @@ def update_secondary_metadata(
                 case Platform.ILLUMINA, AnalysisType.NUCLEIC_ACID_SEQUENCING:
                     log.info("Illumina", item=i, path=p)
                     updated = illumina.ensure_secondary_metadata_updated(
-                        rods_item, mlwh_session
+                        rods_item, mlwh_session, include_controls=False
                     )
                 case Platform.OXFORD_NANOPORE_TECHNOLOGIES, AnalysisType.NUCLEIC_ACID_SEQUENCING:
                     log.info("ONT", item=i, path=p)


### PR DESCRIPTION
Having a circumstance where an exception is raised for control data makes the processing painful. Instead, the ML warehouse query can be modified to exclude any controls as needed.