### PR TITLE
Add a --end-date option to metadata update scripts

### DIFF
--- a/scripts/apply-ont-metadata
+++ b/scripts/apply-ont-metadata
@@ -41,9 +41,9 @@ secondary metadata (like `update-secondary-metadata` does), but that is purely a
 optimisation to make the data available without waiting for an
 `update-secondary-metadata` to be scheduled. 
 
-Only runs whose ML warehouse records have been updated recently are updated. The default
-window for detecting changes is the 14 days prior to the time when the script is run.
-This can be changed using the --begin-date CLI option.
+Only runs whose ML warehouse records have been updated within the specified date range.
+The default window for detecting changes is the 14 days prior to the time when the
+script is run. This can be changed using the --begin-date and --end-date CLI options.
 """
 
 parser = argparse.ArgumentParser(
@@ -54,11 +54,20 @@ add_logging_arguments(parser)
 parser.add_argument(
     "--begin-date",
     "--begin_date",
-    help="Limit runs found to those changed after this date. Defaults to 14 days ago. "
-    "The argument must be an ISO8601 UTC date or date and time e.g. 2022-01-30, "
-    "2022-01-30T11:11:03Z",
+    help="Limit runs found to those changed at, or after this date. Defaults to "
+    "14 days ago. The argument must be an ISO8601 UTC date or date and time "
+    "e.g. 2022-01-30, 2022-01-30T11:11:03Z",
     type=parse_iso_date,
     default=datetime.now() - timedelta(days=14),
+)
+parser.add_argument(
+    "--end-date",
+    "--end_date",
+    help="Limit runs found to those changed at, or before this date. Defaults to "
+    "the current time. The argument must be an ISO8601 UTC date or date and time "
+    "e.g. 2022-01-30, 2022-01-30T11:11:03Z",
+    type=parse_iso_date,
+    default=datetime.now(),
 )
 parser.add_argument(
     "--zone",
@@ -70,6 +79,8 @@ parser.add_argument(
 parser.add_argument(
     "--database-config",
     "--database_config",
+    "--db-config",
+    "--db_config",
     help="Configuration file for database connection.",
     type=argparse.FileType("r"),
     required=True,

--- a/scripts/locate-data-objects
+++ b/scripts/locate-data-objects
@@ -97,6 +97,8 @@ add_logging_arguments(parser)
 parser.add_argument(
     "--database-config",
     "--database_config",
+    "--db-config",
+    "--db_config",
     help="Configuration file for database connection",
     type=argparse.FileType("r"),
     required=True,
@@ -160,11 +162,20 @@ ilup_parser = subparsers.add_parser(
 ilup_parser.add_argument(
     "--begin-date",
     "--begin_date",
-    help="Limit data objects found to those changed after this date. Defaults to 14 "
-    "days ago. The argument must be an ISO8601 UTC date or date and time e.g. "
-    "2022-01-30, 2022-01-30T11:11:03Z",
+    help="Limit data objects found to those whose metadata was changed in the ML "
+    "warehouse at, or after after this date. Defaults to 14 days ago. The argument "
+    "must be an ISO8601 UTC date or date and time e.g. 2022-01-30, 2022-01-30T11:11:03Z",
     type=parse_iso_date,
     default=datetime.now(timezone.utc) - timedelta(days=14),
+)
+ilup_parser.add_argument(
+    "--end-date",
+    "--end_date",
+    help="Limit data objects found to those whose metadata was changed in the ML "
+    "warehouse at, or before this date. Defaults to the current time. The argument "
+    "must be an ISO8601 UTC date or date and time e.g. 2022-01-30, 2022-01-30T11:11:03Z",
+    type=parse_iso_date,
+    default=datetime.now(),
 )
 ilup_parser.add_argument(
     "--skip-absent-runs",
@@ -185,17 +196,22 @@ def illumina_updates(cli_args):
     with Session(engine) as session:
         num_processed = num_errors = 0
 
-        iso_date = cli_args.begin_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        iso_begin = cli_args.begin_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        iso_end = cli_args.end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
         skip_absent_runs = cli_args.skip_absent_runs
 
         attempts_per_run = defaultdict(int)
         success_per_run = defaultdict(int)
 
         for i, c in enumerate(
-            illumina.find_components_changed(session, since=cli_args.begin_date)
+            illumina.find_updated_components(
+                session, since=cli_args.begin_date, until=cli_args.end_date
+            )
         ):
             num_processed += 1
-            log.info("Finding data objects", item=i, component=c, since=iso_date)
+            log.info(
+                "Finding data objects", item=i, comp=c, since=iso_begin, until=iso_end
+            )
 
             try:
                 avus = [
@@ -212,8 +228,9 @@ def illumina_updates(cli_args):
                     log.info(
                         "Skipping run after unsuccessful attempts to find it",
                         item=i,
-                        component=c,
-                        since=iso_date,
+                        comp=c,
+                        since=iso_begin,
+                        until=iso_end,
                         attempts=attempts_per_run[c.id_run],
                     )
                     continue
@@ -255,6 +272,15 @@ ontup_parser.add_argument(
     default=datetime.now(timezone.utc) - timedelta(days=14),
 )
 ontup_parser.add_argument(
+    "--end-date",
+    "--end_date",
+    help="Limit collections found to those changed before date. Defaults to the"
+    "current time. The argument must be an ISO8601 UTC date or date and time e.g."
+    " 2022-01-30, 2022-01-30T11:11:03Z",
+    type=parse_iso_date,
+    default=datetime.now(),
+)
+ontup_parser.add_argument(
     "--report-tags",
     "--report_tags",
     help="Include barcode sub-collections of runs containing de-multiplexed data.",
@@ -267,16 +293,22 @@ def ont_updates(cli_args):
     engine = sqlalchemy.create_engine(dbconfig.url)
     with Session(engine) as session:
         num_processed = num_errors = 0
-        iso_date = cli_args.begin_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        iso_begin = cli_args.begin_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        iso_end = cli_args.end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
         report_tags = cli_args.report_tags
 
         for i, c in enumerate(
-            ont.find_components_changed(
-                session, include_tags=report_tags, since=cli_args.begin_date
+            ont.find_updated_components(
+                session,
+                include_tags=report_tags,
+                since=cli_args.begin_date,
+                until=cli_args.end_date,
             )
         ):
             num_processed += 1
-            log.info("Finding collections", item=i, component=c, since=iso_date)
+            log.info(
+                "Finding collections", item=i, comp=c, since=iso_begin, until=iso_end
+            )
 
             try:
                 avus = [

--- a/scripts/update-secondary-metadata
+++ b/scripts/update-secondary-metadata
@@ -56,6 +56,8 @@ add_logging_arguments(parser)
 parser.add_argument(
     "--database-config",
     "--database_config",
+    "--db-config",
+    "--db_config",
     help="Configuration file for database connection.",
     type=argparse.FileType("r"),
     required=True,
@@ -102,7 +104,6 @@ parser.add_argument(
 parser.add_argument(
     "--version", help="Print the version and exit.", action="store_true"
 )
-
 parser.add_argument(
     "--zone",
     help="Specify a federated iRODS zone in which to find data objects and/or "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,10 +80,12 @@ TEST_GROUPS = ["ss_1000", "ss_2000", "ss_3000", "ss_4000", "ss_5000", "ss_888"]
 TEST_SQL_STALE_REPLICATE = "setObjectReplStale"
 TEST_SQL_INVALID_CHECKSUM = "setObjectChecksumInvalid"
 
+# Counts of test fixture experiments
 NUM_SIMPLE_EXPTS = 5
 NUM_MULTIPLEXED_EXPTS = 3
 NUM_INSTRUMENT_SLOTS = 5
 
+# Dates when test fixture experiments were done
 BEGIN = datetime(year=2020, month=1, day=1, hour=0, minute=0, second=0)
 EARLY = datetime(year=2020, month=6, day=1, hour=0, minute=0, second=0)
 LATE = datetime(year=2020, month=6, day=14, hour=0, minute=0, second=0)


### PR DESCRIPTION
Adding an --end-date option makes back-filling historic changes easier
by allowing work to be split into smaller, date-range tasks.

Adding this feature required some internal API changes, but as these
are not public, doesn't require a major version bump.
