### PR TITLE
Add new study groups for human

### DIFF
--- a/src/npg_irods/illumina.py
+++ b/src/npg_irods/illumina.py
@@ -234,7 +234,7 @@ def ensure_secondary_metadata_updated(
         for fc in flowcells:
             secondary_metadata.extend(sample_fn(fc.sample))
             secondary_metadata.extend(study_fn(fc.study))
-            acl.extend(acl_fn(fc.sample, fc.study, zone=zone))
+            acl.extend(acl_fn(c.subset, fc.sample, fc.study, zone=zone))
 
     # Remove duplicates
     secondary_metadata = sorted(set(secondary_metadata))
@@ -248,7 +248,7 @@ def ensure_secondary_metadata_updated(
         cons_update = ensure_consent_withdrawn(item)
     elif any(c.contains_nonconsented_human() for c in components):  # Illumina specific
         log.info("Non-consented human data", path=item)
-        xahu_update = ensure_consent_withdrawn(item)
+        xahu_update = update_permissions(item, acl)
     else:
         perm_update = update_permissions(item, acl)
 

--- a/src/npg_irods/illumina.py
+++ b/src/npg_irods/illumina.py
@@ -234,7 +234,7 @@ def ensure_secondary_metadata_updated(
         for fc in flowcells:
             secondary_metadata.extend(sample_fn(fc.sample))
             secondary_metadata.extend(study_fn(fc.study))
-            acl.extend(acl_fn(c.subset, fc.sample, fc.study, zone=zone))
+            acl.extend(acl_fn(fc.sample, fc.study, c.subset, zone=zone))
 
     # Remove duplicates
     secondary_metadata = sorted(set(secondary_metadata))

--- a/src/npg_irods/illumina.py
+++ b/src/npg_irods/illumina.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2023 Genome Research Ltd. All rights reserved.
+# Copyright © 2023, 2024 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -234,7 +234,7 @@ def ensure_secondary_metadata_updated(
         for fc in flowcells:
             secondary_metadata.extend(sample_fn(fc.sample))
             secondary_metadata.extend(study_fn(fc.study))
-            acl.extend(acl_fn(fc.sample, fc.study, c.subset, zone=zone))
+            acl.extend(acl_fn(fc.sample, fc.study, subset=c.subset, zone=zone))
 
     # Remove duplicates
     secondary_metadata = sorted(set(secondary_metadata))

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -168,7 +168,7 @@ def make_reduced_study_metadata(study: Study) -> list[AVU]:
     return [avu_if_value(TrackedStudy.ID, study.id_study_lims)]
 
 
-def make_sample_acl(sample: Sample, study: Study, zone=None) -> list[AC]:
+def make_sample_acl(seq:SeqConcept, sample: Sample, study: Study, zone=None) -> list[AC]:
     """Returns an ACL for a given Sample in a Study.
 
     This method takes into account all factors influencing access control, which are:
@@ -192,8 +192,12 @@ def make_sample_acl(sample: Sample, study: Study, zone=None) -> list[AC]:
     Returns:
         An ACL
     """
-    irods_group = f"{STUDY_IDENTIFIER_PREFIX}{study.id_study_lims}"
-    perm = Permission.NULL if sample.consent_withdrawn else Permission.READ
+    print(seq)
+    if seq is not None and seq.value == "human":
+        irods_group = f"{STUDY_IDENTIFIER_PREFIX}{study.id_study_lims}_human"
+    else:
+        irods_group = f"{STUDY_IDENTIFIER_PREFIX}{study.id_study_lims}"
+    perm = Permission.NULL if sample.consent_withdrawn or (seq is not None and seq.value == "xahuman") else Permission.READ
 
     return [AC(irods_group, perm, zone=zone)]
 

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -169,7 +169,7 @@ def make_reduced_study_metadata(study: Study) -> list[AVU]:
 
 
 def make_sample_acl(
-    sample: Sample, study: Study, subset: SeqSubset=None, zone=None
+    sample: Sample, study: Study, subset: SeqSubset = None, zone=None
 ) -> list[AC]:
     """Returns an ACL for a given Sample in a Study.
 

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -186,6 +186,7 @@ def make_sample_acl(
     Note that this function does not check that the sample is in the study.
 
     Args:
+        seq: Sequencing terminology, unique to illumina  
         sample: A sample, which will be used to confirm consent, which modifies the
                 ACL.
         study: A study, which will provide permissions for the ACL.
@@ -194,7 +195,6 @@ def make_sample_acl(
     Returns:
         An ACL
     """
-    print(seq)
     if seq is not None and seq.value == "human":
         irods_group = f"{STUDY_IDENTIFIER_PREFIX}{study.id_study_lims}_human"
     else:

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -37,6 +37,7 @@ from structlog import get_logger
 
 from npg_irods.db.mlwh import Sample, Study
 from npg_irods.metadata.common import (
+    SeqConcept,
     SeqSubset,
     ensure_avus_present,
     avu_if_value,

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -37,7 +37,7 @@ from structlog import get_logger
 
 from npg_irods.db.mlwh import Sample, Study
 from npg_irods.metadata.common import (
-    SeqConcept,
+    SeqSubset,
     ensure_avus_present,
     avu_if_value,
 )
@@ -169,7 +169,7 @@ def make_reduced_study_metadata(study: Study) -> list[AVU]:
 
 
 def make_sample_acl(
-    seq: SeqConcept, sample: Sample, study: Study, zone=None
+    sample: Sample, study: Study, subset: SeqSubset=None, zone=None
 ) -> list[AC]:
     """Returns an ACL for a given Sample in a Study.
 
@@ -186,7 +186,7 @@ def make_sample_acl(
     Note that this function does not check that the sample is in the study.
 
     Args:
-        seq: Platform-independent concepts
+        subset: Subset of sequence reads
         sample: A sample, which will be used to confirm consent, which modifies the
                 ACL.
         study: A study, which will provide permissions for the ACL.
@@ -195,15 +195,14 @@ def make_sample_acl(
     Returns:
         An ACL
     """
-    if seq is not None and seq.value == "human":
+    if subset is not None and subset is subset.XAHUMAN:
+        return []
+
+    if subset is not None and subset is subset.HUMAN:
         irods_group = f"{STUDY_IDENTIFIER_PREFIX}{study.id_study_lims}_human"
     else:
         irods_group = f"{STUDY_IDENTIFIER_PREFIX}{study.id_study_lims}"
-    perm = (
-        Permission.NULL
-        if sample.consent_withdrawn or (seq is not None and seq.value == "xahuman")
-        else Permission.READ
-    )
+    perm = Permission.NULL if sample.consent_withdrawn else Permission.READ
 
     return [AC(irods_group, perm, zone=zone)]
 

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -168,7 +168,9 @@ def make_reduced_study_metadata(study: Study) -> list[AVU]:
     return [avu_if_value(TrackedStudy.ID, study.id_study_lims)]
 
 
-def make_sample_acl(seq:SeqConcept, sample: Sample, study: Study, zone=None) -> list[AC]:
+def make_sample_acl(
+    seq: SeqConcept, sample: Sample, study: Study, zone=None
+) -> list[AC]:
     """Returns an ACL for a given Sample in a Study.
 
     This method takes into account all factors influencing access control, which are:
@@ -197,7 +199,11 @@ def make_sample_acl(seq:SeqConcept, sample: Sample, study: Study, zone=None) -> 
         irods_group = f"{STUDY_IDENTIFIER_PREFIX}{study.id_study_lims}_human"
     else:
         irods_group = f"{STUDY_IDENTIFIER_PREFIX}{study.id_study_lims}"
-    perm = Permission.NULL if sample.consent_withdrawn or (seq is not None and seq.value == "xahuman") else Permission.READ
+    perm = (
+        Permission.NULL
+        if sample.consent_withdrawn or (seq is not None and seq.value == "xahuman")
+        else Permission.READ
+    )
 
     return [AC(irods_group, perm, zone=zone)]
 

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -186,7 +186,7 @@ def make_sample_acl(
     Note that this function does not check that the sample is in the study.
 
     Args:
-        seq: Sequencing terminology, unique to illumina  
+        seq: Sequencing terminology, unique to illumina
         sample: A sample, which will be used to confirm consent, which modifies the
                 ACL.
         study: A study, which will provide permissions for the ACL.

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -186,7 +186,7 @@ def make_sample_acl(
     Note that this function does not check that the sample is in the study.
 
     Args:
-        seq: Sequencing terminology, unique to illumina
+        seq: Platform-independent concepts
         sample: A sample, which will be used to confirm consent, which modifies the
                 ACL.
         study: A study, which will provide permissions for the ACL.

--- a/src/npg_irods/metadata/lims.py
+++ b/src/npg_irods/metadata/lims.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2021, 2022, 2023 Genome Research Ltd. All rights reserved.
+# Copyright © 2021, 2022, 2023, 2024 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -187,10 +187,10 @@ def make_sample_acl(
     Note that this function does not check that the sample is in the study.
 
     Args:
-        subset: Subset of sequence reads
         sample: A sample, which will be used to confirm consent, which modifies the
                 ACL.
         study: A study, which will provide permissions for the ACL.
+        subset: Subset of sequence reads.
         zone: The iRODS zone.
 
     Returns:

--- a/src/npg_irods/ont.py
+++ b/src/npg_irods/ont.py
@@ -505,7 +505,7 @@ def _do_secondary_metadata_and_perms_update(
 
     acl = []
     for fc in flowcells:
-        acl.extend(make_sample_acl(None, fc.sample, fc.study, zone=zone))
+        acl.extend(make_sample_acl(fc.sample, fc.study, zone=zone))
 
     recurse = item.rods_type == Collection
     cons_update = perm_update = False

--- a/src/npg_irods/ont.py
+++ b/src/npg_irods/ont.py
@@ -505,7 +505,7 @@ def _do_secondary_metadata_and_perms_update(
 
     acl = []
     for fc in flowcells:
-        acl.extend(make_sample_acl(fc.sample, fc.study, zone=zone))
+        acl.extend(make_sample_acl(None, fc.sample, fc.study, zone=zone))
 
     recurse = item.rods_type == Collection
     cons_update = perm_update = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1029,6 +1029,13 @@ def illumina_synthetic_irods(tmp_path):
             *run_pos,
             AVU(tag, 1),
         ),
+        "12345/12345#1_xahuman.cram": (
+            AVU(idp, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+            AVU(cmp, '{"id_run":12345, "position":1, "tag_index":1, "subset":"xahuman"}'),
+            AVU(cmp, '{"id_run":12345, "position":2, "tag_index":1, "subset":"xahuman"}'),
+            *run_pos,
+            AVU(tag, 1),
+        ),
         "12345/12345#2.cram": (
             AVU(idp, "0b3bd00f1d186247f381aa87e213940b8c7ab7e5"),
             AVU(cmp, '{"id_run":12345, "position":1, "tag_index":2}'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2020, 2022, 2023 Genome Research Ltd. All rights reserved.
+# Copyright © 2020, 2022, 2023, 2024 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1031,8 +1031,12 @@ def illumina_synthetic_irods(tmp_path):
         ),
         "12345/12345#1_xahuman.cram": (
             AVU(idp, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-            AVU(cmp, '{"id_run":12345, "position":1, "tag_index":1, "subset":"xahuman"}'),
-            AVU(cmp, '{"id_run":12345, "position":2, "tag_index":1, "subset":"xahuman"}'),
+            AVU(
+                cmp, '{"id_run":12345, "position":1, "tag_index":1, "subset":"xahuman"}'
+            ),
+            AVU(
+                cmp, '{"id_run":12345, "position":2, "tag_index":1, "subset":"xahuman"}'
+            ),
             *run_pos,
             AVU(tag, 1),
         ),

--- a/tests/test_illumina.py
+++ b/tests/test_illumina.py
@@ -412,7 +412,7 @@ class TestIlluminaPermissionsUpdate:
 
     @m.context("When data are multiplexed")
     @m.context("When data contain a human subset")
-    @m.it("Removes managed access permissions")
+    @m.it("Update managed access permissions to restricted human access group")
     def test_updates_human_permissions_mx(
         self, illumina_synthetic_irods, illumina_synthetic_mlwh
     ):

--- a/tests/test_illumina.py
+++ b/tests/test_illumina.py
@@ -425,7 +425,10 @@ class TestIlluminaPermissionsUpdate:
             AC("irods", perm=Permission.OWN, zone=zone),
             AC("ss_4000", perm=Permission.READ, zone=zone),
         ]
-        new_permissions = [AC("irods", perm=Permission.OWN, zone=zone)]
+        new_permissions = [
+            AC("irods", perm=Permission.OWN, zone=zone),
+            AC("ss_4000_human", perm=Permission.READ, zone=zone),               
+        ]
 
         for obj in [DataObject(path), DataObject(qc_path)]:
             obj.add_permissions(*old_permissions)

--- a/tests/test_illumina.py
+++ b/tests/test_illumina.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2023 Genome Research Ltd. All rights reserved.
+# Copyright © 2023, 2024 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -412,7 +412,7 @@ class TestIlluminaPermissionsUpdate:
 
     @m.context("When data are multiplexed")
     @m.context("When data contain a human subset")
-    @m.it("Update managed access permissions to restricted human access group")
+    @m.it("Updates managed access permissions to restricted human access group")
     def test_updates_human_permissions_mx(
         self, illumina_synthetic_irods, illumina_synthetic_mlwh
     ):

--- a/tests/test_illumina.py
+++ b/tests/test_illumina.py
@@ -427,7 +427,7 @@ class TestIlluminaPermissionsUpdate:
         ]
         new_permissions = [
             AC("irods", perm=Permission.OWN, zone=zone),
-            AC("ss_4000_human", perm=Permission.READ, zone=zone),               
+            AC("ss_4000_human", perm=Permission.READ, zone=zone),
         ]
 
         for obj in [DataObject(path), DataObject(qc_path)]:

--- a/tests/test_locate_data_objects.py
+++ b/tests/test_locate_data_objects.py
@@ -20,6 +20,7 @@ class TestLocateDataObjects:
                 "12345#1.cram",
                 "12345#1_human.cram",
                 "12345#1_phix.cram",
+                "12345#1_xahuman.cram",
                 "12345#2.cram",
                 "12345#888.cram",
                 "12345.cram",

--- a/tests/test_pacbio.py
+++ b/tests/test_pacbio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2023 Genome Research Ltd. All rights reserved.
+# Copyright © 2023, 2024 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
I've implemented this so a irods group of ss_<studyid>_human get's added when the component has a subset of "human". I'm not sure if this is the best way to do it so open to feedback :D 

I was also thinking for line 249 in `src/npg_irods/illumina.py`
`elif any(c.contains_nonconsented_human() for c in components): # Illumina specific`
does It make sense to still implement it this way as now the logic for a subset of "human" and "xahuman" is different so maybe we make the distinction here and use two separate methods instead of having the logic inside the method? Hopefully that makes sense.