### PR TITLE
Fix inclusion of controls (controls to be included)

### DIFF
--- a/src/npg_irods/utilities.py
+++ b/src/npg_irods/utilities.py
@@ -626,7 +626,7 @@ def update_secondary_metadata(
                 case Platform.ILLUMINA, AnalysisType.NUCLEIC_ACID_SEQUENCING:
                     log.info("Illumina", item=i, path=p)
                     updated = illumina.ensure_secondary_metadata_updated(
-                        rods_item, mlwh_session, include_controls=False
+                        rods_item, mlwh_session, include_controls=True
                     )
                 case Platform.PACBIO, AnalysisType.NUCLEIC_ACID_SEQUENCING:
                     log.info("PacBio", item=i, path=p)

--- a/tests/illumina/test_metadata_update.py
+++ b/tests/illumina/test_metadata_update.py
@@ -511,6 +511,32 @@ class TestIlluminaPermissionsUpdate:
             )
             assert obj.permissions() == new_permissions
 
+    @m.context("When the data are multiplexed")
+    @m.context("When the tag index is for a control")
+    @m.it("Manages permissions while respecting the include_controls option")
+    def test_updates_control_permissions_mx(
+        self, illumina_synthetic_irods, illumina_synthetic_mlwh
+    ):
+        path = illumina_synthetic_irods / "12345/12345#888.cram"
+
+        obj = DataObject(path)
+        old_permissions = [AC("irods", perm=Permission.OWN, zone="testZone")]
+        new_permissions = [
+            AC("irods", perm=Permission.OWN, zone="testZone"),
+            AC("ss_888", perm=Permission.READ, zone="testZone"),
+        ]
+
+        assert obj.permissions() == old_permissions
+        assert not ensure_secondary_metadata_updated(
+            obj, mlwh_session=illumina_synthetic_mlwh, include_controls=False
+        )
+        assert obj.permissions() == old_permissions
+
+        assert ensure_secondary_metadata_updated(
+            obj, mlwh_session=illumina_synthetic_mlwh, include_controls=True
+        )
+        assert obj.permissions() == new_permissions
+
     @m.context("When data are not multiplexed")
     @m.context("When data have had consent withdrawn")
     @m.it("Does not restore access permissions")


### PR DESCRIPTION
Filtering controls in the DB query has the unwanted side effect that they are still updated, but as there are no flowcells in the resultset for e.g. PhiX, the PhiX stud permissions are removed from the data object.