### PR TITLE
Generalise setting public access for ONT

### DIFF
--- a/tests/ont/test_metadata_update.py
+++ b/tests/ont/test_metadata_update.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2021, 2022, 2023 Genome Research Ltd. All rights reserved.
+# Copyright © 2021, 2022, 2023, 2024 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -370,6 +370,7 @@ class TestONTMetadataUpdate(object):
 class TestONTPermissionsUpdate:
     @tests_have_admin
     @m.context("When ONT permissions are updated")
+    @m.contect("When the experiment is multiplexed")
     @m.it("Makes report files publicly readable")
     def test_public_read_reports(self, ont_synthetic_irods, ont_synthetic_mlwh):
         zone = "testZone"


### PR DESCRIPTION
Widen the types of file that get public access, where appropriate (in line with the way this is done for Illumina).