### PR TITLE
Fix name of enhance-secondary-metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ homepage = "https://github.com/wtsi-npg/npg-irods-python"
 repository = "https://github.com/wtsi-npg/npg-irods-python.git"
 
 [project.scripts]
-"enhance_secondary_metadata" = "npg_irods.cli.enhance_secondary_metadata:main"
+"enhance-secondary-metadata" = "npg_irods.cli.enhance_secondary_metadata:main"
 "apply-ont-metadata" = "npg_irods.cli.apply_ont_metadata:main"
 "check-checksums" = "npg_irods.cli.check_checksums:main"
 "check-common-metadata" = "npg_irods.cli.check_common_metadata:main"

--- a/src/npg_irods/cli/enhance_secondary_metadata.py
+++ b/src/npg_irods/cli/enhance_secondary_metadata.py
@@ -31,8 +31,8 @@ from npg_irods.version import version
 description = """
 Reads iRODS data object paths from a file or STDIN, one per line.
 
-Create-else-update either sample, or study, or both, metadata given existing _id metadata 
-on the given iRODS collection or data-object.
+Create-else-update either sample, or study, or both, metadata given existing _id
+metadata on the given iRODS collection or data object.
 """
 
 parser = argparse.ArgumentParser(
@@ -43,7 +43,8 @@ add_logging_arguments(parser)
 parser.add_argument(
     "-i",
     "--input",
-    help="Input filename. File has one iRODS data object path per line to be updated with secondary study/sample metadata",
+    help="Input filename. File has one iRODS data object path per line to be "
+    "updated with secondary study/sample metadata",
     type=argparse.FileType("r"),
     default=sys.stdin,
 )


### PR DESCRIPTION
The executable naming convention used dashes, not underscores.

Wrapped some over-logncomment lines.