### PR TITLE
Set a clean PATH and PYTHONPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ WORKDIR /app
 COPY . .
 
 ENV PYENV_ROOT "/app/.pyenv"
-ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+
+# Put PYENV first to ensure we use the pyenv-installed Python
+ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 
 RUN ./docker/install_pyenv.sh
 
@@ -49,8 +51,11 @@ RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selectio
     unattended-upgrade -d -v
 
 ENV PYENV_ROOT "/app/.pyenv"
-ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+
+# Put PYENV first to ensure we use the pyenv-installed Python
+ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 ENV PYTHONUNBUFFERED 1
+ENV PYTHONPATH ""
 
 WORKDIR /app
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,7 +3,10 @@
 set -e
 
 export PYENV_ROOT="/app/.pyenv"
-export PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+
+# Put PYENV first to ensure we use the pyenv-installed Python
+export PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:/bin:/usr/bin:/usr/local/bin"
 export PYTHONUNBUFFERED=1
+export PYTHONPATH=""
 
 exec "$@"


### PR DESCRIPTION
When run with Singularity it's possible to have executables and Python modules be mounted into the container accidentally e.g. via Singularity's automatic mounting of home directories.

These changes ensure that the PATH and PYTHONPATH are set explicitly to reduce the chance of running code other than that included in the image.