### PR TITLE
Fix handling of PendingRollbackError when processing large datasets

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       IMAGE_NAME: npg-irods-python
       REPOSITORY_OWNER: ${{ github.repository_owner }}
-      PYTHON_VERSION: "3.10"
+      PYTHON_VERSION: "3.12"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
         shell: bash -l -e -o pipefail {0}
 
     env:
-      PYTHON_VERSION: "3.10"
+      PYTHON_VERSION: "3.12"
       SINGULARITY_VERSION: "3.11.1"
 
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 keywords = ["irods", "npg"]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 dynamic = ["version"]
 

--- a/src/npg_irods/cli/enhance_secondary_metadata.py
+++ b/src/npg_irods/cli/enhance_secondary_metadata.py
@@ -97,16 +97,17 @@ def main():
         sys.exit(0)
 
     dbconfig = DBConfig.from_file(args.db_config.name, "mlwh_ro")
+    engine = sqlalchemy.create_engine(
+        dbconfig.url, pool_pre_ping=True, pool_recycle=3600
+    )
 
-    engine = sqlalchemy.create_engine(dbconfig.url)
-    with Session(engine) as session:
-        num_processed, num_updated, num_errors = update_general_metadata(
-            args.input,
-            args.output,
-            session,
-            print_update=args.print_update,
-            print_fail=args.print_fail,
-        )
+    num_processed, num_updated, num_errors = update_general_metadata(
+        args.input,
+        args.output,
+        engine,
+        print_update=args.print_update,
+        print_fail=args.print_fail,
+    )
 
     if num_errors:
         log.error(

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -663,8 +663,9 @@ class TestMetadataUtilities:
         with StringIO("\n".join(obj_paths)) as reader:
             print(reader.getvalue())
             with StringIO() as writer:
+                engine = general_synthetic_mlwh.get_bind()
                 num_processed, num_updated, num_errors = update_general_metadata(
-                    reader, writer, general_synthetic_mlwh, print_update=True
+                    reader, writer, engine, print_update=True
                 )
                 assert num_processed == 1
                 assert num_updated == 1
@@ -706,8 +707,9 @@ class TestMetadataUtilities:
         with StringIO("\n".join(obj_paths)) as reader:
             print(reader.getvalue())
             with StringIO() as writer:
+                engine = general_synthetic_mlwh.get_bind()
                 num_processed, num_updated, num_errors = update_general_metadata(
-                    reader, writer, general_synthetic_mlwh, print_update=True
+                    reader, writer, engine, print_update=True
                 )
                 assert num_processed == 1
                 assert num_updated == 1
@@ -742,8 +744,9 @@ class TestMetadataUtilities:
         with StringIO("\n".join(obj_paths)) as reader:
             print(reader.getvalue())
             with StringIO() as writer:
+                engine = general_synthetic_mlwh.get_bind()
                 num_processed, num_updated, num_errors = update_general_metadata(
-                    reader, writer, general_synthetic_mlwh, print_update=True
+                    reader, writer, engine, print_update=True
                 )
                 assert num_processed == 1
                 assert num_updated == 1


### PR DESCRIPTION
This exception is raised when the database disconnects mid-operation and has to be handled outside the ORM.

This change includes some changes to the DB engine init args which make getting bad/stale connections less likely. It also changes the main work loop to operate on batches of paths, using a fresh DB session for each and adds handling for the remainder of a batch should an exception occur somewhere in the middle of it. SQLAlchemy errors are handled specially, by propagating them up to where they can trigger a rollback and allow work to continue with a new DB session.

This updates the Python version requirement to 3.12 (to get itertools.batched())