### PR TITLE
Fix performance issue where debug code was left in production

### DIFF
--- a/src/npg_irods/cli/update_secondary_metadata.py
+++ b/src/npg_irods/cli/update_secondary_metadata.py
@@ -22,7 +22,6 @@ import sys
 
 import sqlalchemy
 import structlog
-from sqlalchemy.orm import Session
 
 from npg_irods.cli.util import (
     add_db_config_arguments,


### PR DESCRIPTION
The expected names of cram/bam files associated with ancillary files are known, so there is no need to repeatedly iterate the collections. Also, associateion of a stem with a cram/bam file can be cached.