### PR TITLE
Use dataclasses for configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "NPG iRODS data management tools."
 license = { file = "LICENSE", content-type = "text/plain" }
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [{ name = "Keith James", email = "kdj@sanger.ac.uk" },
-           { name = "Michael Kubiak", email = "mk35@sanger.ac.uk" }]
+    { name = "Michael Kubiak", email = "mk35@sanger.ac.uk" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -16,19 +16,23 @@ requires-python = ">=3.12"
 dynamic = ["version"]
 
 dependencies = [
+    "npg-python-lib",
     "npg_id_generation",
     "partisan",
+    "pymysql",
     "python-dateutil",
     "rich",
     "sqlalchemy",
     "structlog",
+    "yattag",
 ]
 
 [project.optional-dependencies]
 test = [
     "black",
     "pytest",
-    "pytest-it"
+    "pytest-it",
+    "sqlalchemy-utils"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==43.0.1
 npg_id_generation@https://github.com/wtsi-npg/npg_id_generation/releases/download/5.0.1/npg_id_generation-5.0.1.tar.gz
-npg-python-lib@https://github.com/wtsi-npg/npg-python-lib/releases/download/0.2.0/npg_python_lib-0.2.0.tar.gz
+npg-python-lib@https://github.com/wtsi-npg/npg-python-lib/releases/download/0.3.1/npg_python_lib-0.3.1.tar.gz
 partisan@https://github.com/wtsi-npg/partisan/releases/download/2.12.0/partisan-2.12.0.tar.gz
 pymysql==1.1.1
 python-dateutil==2.9.0.post0

--- a/src/npg_irods/cli/apply_ont_metadata.py
+++ b/src/npg_irods/cli/apply_ont_metadata.py
@@ -27,10 +27,12 @@ from npg.cli import (
     add_db_config_arguments,
     add_logging_arguments,
 )
+
+from npg.conf import IniData
 from npg.log import configure_structlog
 from sqlalchemy.orm import Session
 
-from npg_irods.db import DBConfig
+from npg_irods import db
 from npg_irods.ont import apply_metadata
 from npg_irods.version import version
 
@@ -83,7 +85,7 @@ def main():
         print(version())
         sys.exit(0)
 
-    dbconfig = DBConfig.from_file(args.db_config.name, "mlwh_ro")
+    dbconfig = IniData(db.Config).from_file(args.db_config.name, "mlwh_ro")
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )

--- a/src/npg_irods/cli/locate_data_objects.py
+++ b/src/npg_irods/cli/locate_data_objects.py
@@ -31,13 +31,14 @@ from npg.cli import (
     add_logging_arguments,
     integer_in_range,
 )
+from npg.conf import IniData
 from npg.iter import with_previous
 from npg.log import configure_structlog
 from partisan.irods import AVU, DataObject, query_metadata
 from sqlalchemy.orm import Session
 
-from npg_irods import illumina, ont, pacbio, sequenom
-from npg_irods.db import DBConfig
+from npg_irods import db, illumina, ont, pacbio, sequenom
+
 from npg_irods.db.mlwh import (
     find_consent_withdrawn_samples,
     find_updated_samples,
@@ -109,7 +110,7 @@ log = structlog.get_logger("main")
 
 
 def consent_withdrawn(cli_args: argparse.ArgumentParser):
-    dbconfig = DBConfig.from_file(cli_args.db_config.name, "mlwh_ro")
+    dbconfig = IniData(db.Config).from_file(cli_args.db_config.name, "mlwh_ro")
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )
@@ -153,7 +154,7 @@ def consent_withdrawn(cli_args: argparse.ArgumentParser):
 def illumina_updates_cli(cli_args: argparse.ArgumentParser):
     """Process the command line arguments for finding Illumina data objects and execute
     the command."""
-    dbconfig = DBConfig.from_file(cli_args.db_config.name, "mlwh_ro")
+    dbconfig = IniData(db.Config).from_file(cli_args.db_config.name, "mlwh_ro")
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )
@@ -267,7 +268,7 @@ def illumina_updates(
 def ont_updates_cli(cli_args: argparse.ArgumentParser):
     """Process the command line arguments for finding ONT data objects and execute the
     command."""
-    dbconfig = DBConfig.from_file(cli_args.db_config.name, "mlwh_ro")
+    dbconfig = IniData(db.Config).from_file(cli_args.db_config.name, "mlwh_ro")
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )
@@ -335,7 +336,7 @@ def ont_updates(
 def pacbio_updates_cli(cli_args: argparse.ArgumentParser):
     """Process the command line arguments for finding PacBio data objects and execute
     the command."""
-    dbconfig = DBConfig.from_file(cli_args.db_config.name, "mlwh_ro")
+    dbconfig = IniData(db.Config).from_file(cli_args.db_config.name, "mlwh_ro")
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )
@@ -424,7 +425,7 @@ def pacbio_updates(
 def infinium_updates_cli(cli_args: argparse.ArgumentParser):
     """Process the command line arguments for finding Infinium microarray data objects
     and execute the command."""
-    dbconfig = DBConfig.from_file(cli_args.db_config.name, "mlwh_ro")
+    dbconfig = IniData(db.Config).from_file(cli_args.db_config.name, "mlwh_ro")
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )
@@ -457,7 +458,7 @@ def infinium_microarray_updates(
 def sequenom_updates_cli(cli_args: argparse.ArgumentParser):
     """Process the command line arguments for finding Sequenom genotype data objects
     and execute the command."""
-    dbconfig = DBConfig.from_file(cli_args.db_config.name, "mlwh_ro")
+    dbconfig = IniData(db.Config).from_file(cli_args.db_config.name, "mlwh_ro")
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )

--- a/src/npg_irods/cli/update_secondary_metadata.py
+++ b/src/npg_irods/cli/update_secondary_metadata.py
@@ -23,9 +23,10 @@ import sys
 import sqlalchemy
 import structlog
 from npg.cli import add_db_config_arguments, add_io_arguments, add_logging_arguments
+from npg.conf import IniData
 from npg.log import configure_structlog
 
-from npg_irods.db import DBConfig
+from npg_irods import db
 from npg_irods.utilities import update_secondary_metadata
 from npg_irods.version import version
 
@@ -111,7 +112,7 @@ def main():
         print(version())
         sys.exit(0)
 
-    dbconfig = DBConfig.from_file(args.db_config.name, "mlwh_ro")
+    dbconfig = IniData(db.Config).from_file(args.db_config.name, "mlwh_ro")
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )

--- a/src/npg_irods/db/__init__.py
+++ b/src/npg_irods/db/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2023 Genome Research Ltd. All rights reserved.
+# Copyright © 2023, 2024 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,72 +19,27 @@
 
 """Business logic API, schema-specific API and utilities for SQL databases."""
 
-import configparser
-import os
+from dataclasses import dataclass
 from urllib import parse
 
 
-class DBConfig:
+@dataclass
+class Config:
     """A database configuration which falls back on environment variables if values are
     not set in the constructor.
 
     The database URL attribute is currently constructed in MySQL-specific format.
     """
 
-    HOST = "host"
-    PORT = "port"
-    SCHEMA = "schema"
-    USER = "user"
-    PASSWORD = "password"
+    host: str
+    port: str
+    schema: str
+    user: str
+    password: str
 
-    @classmethod
-    def from_file(cls, ini_file, section):
-        parser = configparser.ConfigParser()
-        parser.read(ini_file)
-
-        return cls(
-            parser.get(section, cls.HOST),
-            parser.get(section, cls.PORT),
-            parser.get(section, cls.SCHEMA),
-            parser.get(section, cls.USER),
-            parser.get(section, cls.PASSWORD),
-        )
-
-    def __init__(self, host=None, port=None, schema=None, user=None, password=None):
-        """Creates a new configuration.
-
-        Args:
-            host: The host name. Defaults to the value of the
-              DB_HOST environment variable.
-            port: The host port. Defaults to the value of the
-              DB_PORT environment variable.
-            schema: The database schema name.A host name. Defaults to the value of the
-              DB_SCHEMA environment variable.
-            user: The database user. Defaults to the value of the
-              DB_USER environment variable.
-            password: The user's password. Defaults to the value of the
-              DB_PASSWORD environment variable.
-        """
-        self.host = host if host else os.environ.get("DB_HOST")
-        self.port = port if port else os.environ.get("DB_PORT")
-        self.schema = schema if schema else os.environ.get("DB_SCHEMA")
-        self.user = user if user else os.environ.get("DB_USER")
-        self.password = password if password else os.environ.get("DB_PASSWORD")
-
-        for attr, var in {
-            DBConfig.HOST: "DB_HOST",
-            DBConfig.PORT: "DB_PORT",
-            DBConfig.SCHEMA: "DB_SCHEMA",
-            DBConfig.USER: "DB_USER",
-            DBConfig.PASSWORD: "DB_PASSWORD",
-        }.items():
-            if getattr(self, attr) is None:
-                raise ValueError(
-                    f"Database {attr} not set by configuration or "
-                    f"{var} environment variable"
-                )
-
-        self.url = (
+    @property
+    def url(self):
+        return (
             f"mysql+pymysql://{self.user}:{parse.quote_plus(self.password)}"
             f"@{self.host}:{self.port}/{self.schema}?charset=utf8mb4"
         )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
+black==24.8.0
 pytest-it==0.1.5
 pytest==8.3.3
 sqlalchemy-utils==0.41.2
-black==24.8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ from pathlib import PurePath
 
 import pytest
 import structlog
+from npg.conf import IniData
 from partisan.icommands import (
     iput,
     irm,
@@ -53,12 +54,10 @@ from helpers import (
     remove_test_groups,
     set_replicate_invalid,
 )
-from npg_irods.db import DBConfig
-from npg_irods.db.mlwh import (
-    Base,
-)
+from npg_irods import db
+from npg_irods.db import mlwh
 from npg_irods.metadata.common import DataFile
-from npg_irods.metadata.lims import TrackedSample, TrackedStudy, Study, Sample
+from npg_irods.metadata.lims import Sample, Study, TrackedSample, TrackedStudy
 
 logging.basicConfig(level=logging.ERROR)
 
@@ -87,7 +86,7 @@ def mlwh_session() -> Session:
     """Create an empty ML warehouse database fixture."""
     section = INI_SECTION_GITHUB if is_running_in_github_ci() else INI_SECTION_LOCAL
 
-    dbconfig = DBConfig.from_file(TEST_INI, section)
+    dbconfig = IniData(db.Config).from_file(TEST_INI, section)
     engine = create_engine(dbconfig.url, echo=False)
 
     if database_exists(engine.url):
@@ -100,7 +99,7 @@ def mlwh_session() -> Session:
         conn.execute(text("SET sql_mode = '';"))
         conn.commit()
 
-    Base.metadata.create_all(engine)
+    mlwh.Base.metadata.create_all(engine)
     session_maker = sessionmaker(bind=engine)
     sess: Session() = session_maker()
 


### PR DESCRIPTION
Update npg-python-lib to enable dataclass objects to be created from INI files.

Remove custom config class and parsing code for database configuration; use a dataclass instead.