### PR TITLE
Add --json option to locate-data-objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 dependencies = [
     "npg-python-lib",
     "npg_id_generation >=5.0.1",
-    "partisan >=2.12.0",
+    "partisan >=2.13.0",
     "pymysql >=1.1.1",
     "python-dateutil >=2.9.0,<3",
     "rich >=13.6.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography==43.0.1
 npg_id_generation@https://github.com/wtsi-npg/npg_id_generation/releases/download/5.0.1/npg_id_generation-5.0.1.tar.gz
 npg-python-lib@https://github.com/wtsi-npg/npg-python-lib/releases/download/0.3.1/npg_python_lib-0.3.1.tar.gz
-partisan@https://github.com/wtsi-npg/partisan/releases/download/2.12.0/partisan-2.12.0.tar.gz
+partisan@https://github.com/wtsi-npg/partisan/releases/download/2.13.0/partisan-2.13.0.tar.gz
 pymysql==1.1.1
 python-dateutil==2.9.0.post0
 rich==13.7.1

--- a/src/npg_irods/html_reports.py
+++ b/src/npg_irods/html_reports.py
@@ -120,7 +120,7 @@ def ont_runs_this_year(zone: str = None) -> list[tuple[Collection, datetime]]:
     #
     # Testing with hand-crafted iquest commands shows the COLL_CREATE_TIME is ignored.
     #
-    # sec_since_epoch = (start_of_year.utcnow() - datetime(1970, 1, 1)).total_seconds()
+    # sec_since_epoch = (start_of_year.now(timezone.utc) - datetime(1970, 1, 1)).total_seconds()
     #
     # args = [
     #     "%s %s",

--- a/src/npg_irods/mlwh_locations/illumina.py
+++ b/src/npg_irods/mlwh_locations/illumina.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2022, 2024 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 import json
 
 import structlog
-from typing import List, Dict
+
 from multiprocessing import Pool, pool
 from partisan.irods import DataObject, Collection, client_pool, AVU
 from npg_irods.metadata.common import SeqConcept
@@ -108,7 +108,7 @@ def has_subset(obj: DataObject) -> bool:
     return False
 
 
-def create_product_dict(obj_path: str, ext: str) -> Dict:
+def create_product_dict(obj_path: str, ext: str) -> dict:
     """
     Gathers information about a data object that is required to load
     it into the seq_product_irods_locations table.
@@ -124,7 +124,7 @@ def create_product_dict(obj_path: str, ext: str) -> Dict:
     # rebuild un-pickleable objects inside subprocess
 
     with client_pool(1) as baton_pool:
-        obj = DataObject(obj_path, baton_pool)
+        obj = DataObject(obj_path, pool=baton_pool)
         if has_expected_extension(obj.name, ext) and not is_10x(str(obj.path)):
             product = {
                 "seq_platform_name": ILLUMINA,
@@ -155,8 +155,8 @@ def create_product_dict(obj_path: str, ext: str) -> Dict:
 
 
 def extract_products(
-    results: List[pool.ApplyResult], timeout: int = None
-) -> List[Dict]:
+    results: list[pool.ApplyResult], timeout: int = None
+) -> list[dict]:
     """
     Extracts products from result list and handles errors raised.
 
@@ -180,7 +180,7 @@ def extract_products(
     return products
 
 
-def find_products(coll: Collection, processes: int) -> List[Dict]:
+def find_products(coll: Collection, processes: int) -> list[dict]:
     """
     Recursively finds all (non-human, non-phix) cram data objects in
     a collection.
@@ -215,7 +215,7 @@ def find_products(coll: Collection, processes: int) -> List[Dict]:
     return products
 
 
-def generate_files(colls: List[str], processes: int, out_file: str):
+def generate_files(colls: list[str], processes: int, out_file: str):
     """
     Writes a json file containing information to be loaded into
     seq_product_irods_locations table for each product data object in a set of

--- a/src/npg_irods/mlwh_locations/writer.py
+++ b/src/npg_irods/mlwh_locations/writer.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # @author Michael Kubiak <mk35@sanger.ac.uk>
+
 import json
 from pathlib import PurePath
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,15 @@ INI_SECTION_LOCAL = "docker"
 INI_SECTION_GITHUB = "github"
 
 
+@pytest.fixture(scope="function")
+def irods_groups():
+    try:
+        add_test_groups()
+        yield
+    finally:
+        remove_test_groups()
+
+
 @pytest.fixture(scope="session")
 def sql_test_utilities():
     """Install SQL test utilities for the iRODS backend database."""
@@ -219,7 +228,7 @@ def annotated_data_object(tmp_path):
 
 
 @pytest.fixture(scope="function")
-def simple_study_and_sample_data_object(tmp_path):
+def simple_study_and_sample_data_object(tmp_path, irods_groups):
     """A fixture providing a collection containing a single data object with sample
     and study metadata"""
     root_path = PurePath(
@@ -227,7 +236,6 @@ def simple_study_and_sample_data_object(tmp_path):
     )
     rods_path = add_rods_path(root_path, tmp_path)
 
-    add_test_groups()
     obj_path = rods_path / "lorem.txt"
     iput("./tests/data/simple/data_object/lorem.txt", obj_path)
 
@@ -240,7 +248,6 @@ def simple_study_and_sample_data_object(tmp_path):
         yield obj_path
     finally:
         remove_rods_path(rods_path)
-        remove_test_groups()
 
 
 @pytest.fixture(scope="function")
@@ -294,7 +301,7 @@ def invalid_replica_data_object(tmp_path, sql_test_utilities):
 
 
 @pytest.fixture(scope="function")
-def annotated_collection_tree(tmp_path):
+def annotated_collection_tree(tmp_path, irods_groups):
     """A fixture providing a tree of collections and data objects, with both
     collections and data objects having annotation."""
 
@@ -304,7 +311,6 @@ def annotated_collection_tree(tmp_path):
     iput("./tests/data/tree", rods_path, recurse=True)
     tree_root = rods_path / "tree"
 
-    add_test_groups()
     group_ac = AC("ss_1000", Permission.READ, zone="testZone")
     public_ac = AC("public", Permission.READ, zone="testZone")
 
@@ -327,7 +333,6 @@ def annotated_collection_tree(tmp_path):
         yield tree_root
     finally:
         remove_rods_path(rods_path)
-        remove_test_groups()
 
 
 @pytest.fixture(scope="function")

--- a/tests/illumina/conftest.py
+++ b/tests/illumina/conftest.py
@@ -29,9 +29,7 @@ from helpers import (
     CREATED,
     LATEST,
     add_rods_path,
-    add_test_groups,
     remove_rods_path,
-    remove_test_groups,
 )
 from npg_irods.db.mlwh import IseqFlowcell, IseqProductMetrics, Sample, Study
 from npg_irods.illumina import EntityType
@@ -392,12 +390,11 @@ def illumina_backfill_mlwh(mlwh_session) -> Session:
 
 
 @pytest.fixture(scope="function")
-def illumina_synthetic_irods(tmp_path):
+def illumina_synthetic_irods(tmp_path, irods_groups):
     root_path = PurePath("/testZone/home/irods/test/illumina_synthetic_irods")
     rods_path = add_rods_path(root_path, tmp_path)
 
     Collection(rods_path).create(parents=True)
-    add_test_groups()
 
     run = illumina.Instrument.RUN
     pos = illumina.Instrument.LANE
@@ -499,4 +496,3 @@ def illumina_synthetic_irods(tmp_path):
         yield rods_path / "synthetic"
     finally:
         remove_rods_path(rods_path)
-        remove_test_groups()

--- a/tests/ont/conftest.py
+++ b/tests/ont/conftest.py
@@ -31,9 +31,7 @@ from helpers import (
     LATE,
     LATEST,
     add_rods_path,
-    add_test_groups,
     remove_rods_path,
-    remove_test_groups,
 )
 from npg_irods.db.mlwh import OseqFlowcell, Sample, Study
 from npg_irods.metadata import ont
@@ -226,7 +224,7 @@ def ont_synthetic_mlwh(mlwh_session) -> Session:
 
 
 @pytest.fixture(scope="function")
-def ont_gridion_irods(tmp_path):
+def ont_gridion_irods(tmp_path, irods_groups):
     """A fixture providing a set of files based on output from an ONT GridION
     instrument. This dataset provides an example of file and directory naming
     conventions. The file contents are dummy values."""
@@ -235,17 +233,15 @@ def ont_gridion_irods(tmp_path):
 
     iput("./tests/data/ont/gridion", rods_path, recurse=True)
     expt_root = rods_path / "gridion"
-    add_test_groups()
 
     try:
         yield expt_root
     finally:
         remove_rods_path(rods_path)
-        remove_test_groups()
 
 
 @pytest.fixture(scope="function")
-def ont_synthetic_irods(tmp_path):
+def ont_synthetic_irods(tmp_path, irods_groups):
     """A fixture providing a synthetic set of files and metadata based on output
     from an ONT GridION instrument, modified to represent the way simple and
     multiplexed experiments are laid out. The file contents are dummy values."""
@@ -253,7 +249,6 @@ def ont_synthetic_irods(tmp_path):
     rods_path = add_rods_path(root_path, tmp_path)
 
     expt_root = rods_path / "synthetic"
-    add_test_groups()
 
     for expt in range(1, NUM_SIMPLE_EXPTS + 1):
         for slot in range(1, NUM_INSTRUMENT_SLOTS + 1):
@@ -340,4 +335,3 @@ def ont_synthetic_irods(tmp_path):
         yield expt_root
     finally:
         remove_rods_path(rods_path)
-        remove_test_groups()

--- a/tests/ont/test_metadata_update.py
+++ b/tests/ont/test_metadata_update.py
@@ -17,7 +17,7 @@
 #
 # @author Keith James <kdj@sanger.ac.uk>
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import PurePath
 
 from partisan.irods import AC, AVU, Collection, DataObject, Permission, format_timestamp
@@ -25,12 +25,10 @@ from pytest import mark as m, raises
 
 from helpers import (
     LATEST,
-    add_rods_path,
     history_in_meta,
     remove_rods_path,
     tests_have_admin,
 )
-from ont.conftest import ont_tag_identifier
 from npg_irods import ont
 from npg_irods.metadata.common import SeqConcept
 from npg_irods.metadata.lims import (
@@ -43,10 +41,11 @@ from npg_irods.ont import (
     Instrument,
     annotate_results_collection,
     apply_metadata,
+    barcode_collections,
     ensure_secondary_metadata_updated,
     is_minknow_report,
-    barcode_collections,
 )
+from ont.conftest import ont_tag_identifier
 
 
 class TestONTFindUpdates:
@@ -420,7 +419,7 @@ class TestONTMetadataUpdate(object):
         assert history_in_meta(
             AVU(
                 f"{TrackedStudy.NAME}_history",
-                f"[{format_timestamp(datetime.utcnow())}] Study A,Study B",
+                f"[{format_timestamp(datetime.now(timezone.utc))}] Study A,Study B",
             ),
             coll.metadata(),
         )
@@ -489,7 +488,7 @@ class TestONTMetadataUpdate(object):
                 AVU(Instrument.INSTRUMENT_SLOT, slot),
             )
 
-            samples_paths: tuple[str, Collection] = []
+            samples_paths = []
             for tag_index in range(1, 5):
                 tag_identifier = ont_tag_identifier(tag_index)
                 bpath = (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,8 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # @author Keith James <kdj@sanger.ac.uk>
-
-import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -353,7 +352,7 @@ class TestCreationMetadataAPI:
     @m.context("When creation metadata are created")
     @m.it("Has the correct form")
     def test_make_creation_metadata(self):
-        now = datetime.datetime.utcnow()
+        now = datetime.now(timezone.utc)
         name = "dummy"
         assert make_creation_metadata(name, now) == [
             AVU("dcterms:creator", name),


### PR DESCRIPTION
This option allows data objects to be output in baton JSON format (including metadata and ACLs), rather than simple paths.

Fix some minor issues.