### PR TITLE
Feature: back populate sample_lims and sample_uuid metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ repository = "https://github.com/wtsi-npg/npg-irods-python.git"
 "update-secondary-metadata" = "npg_irods.cli.update_secondary_metadata:main"
 "withdraw-consent" = "npg_irods.cli.withdraw_consent:main"
 "write-html-report" = "npg_irods.cli.write_html_report:main"
+"update-uuid-lims-metadata" = "npg_irods.cli.update_uuid_lims_metadata:main" 
 
 [build-system]
 requires = ["setuptools>=41", "wheel", "setuptools-git-versioning>=2.0,<3"]

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -120,8 +120,12 @@ def add_lims_uuid_to_iRODS_object(path: str, mlwh_session):
             for av in avu_to_add:
                 num_avu_added = iobj.add_metadata(av)
                 if num_avu_added == 1:
+                    msg = f"Added AVU: attribute '{av.attribute}', value '{av.value}' on {iobj}"
+                    log.info(msg)
                     statuses.append(Status.UPDATED)
                 else:
+                    msg = f"Skipped existing AVU: attribute '{av.attribute}', value '{av.value}' on {iobj}"
+                    log.info(msg)
                     statuses.append(Status.SKIPPED)
         return statuses
 

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -21,16 +21,14 @@ import sys
 
 from sqlalchemy import Engine
 import sqlalchemy
-from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 import structlog
-from npg.cli import add_db_config_arguments, add_io_arguments, add_logging_arguments
+from npg.cli import add_db_config_arguments, add_logging_arguments
 from npg.conf import IniData
 from npg.log import configure_structlog
 
 from npg_irods import add_appinfo_structlog_processor, db, version
 
-from npg_irods.common import update_metadata
 from npg_irods.db.mlwh import Sample, session_context
 
 from partisan.irods import make_rods_item, RodsError
@@ -54,6 +52,18 @@ log = structlog.get_logger("main")
 
 
 def add_lims_uuid_from_input(engine: Engine, input):
+    """
+    Add sample_lims and sample_uuid to the metadata objects given in input
+    only if they have sample_id in their metadata.
+
+    Args:
+        engine (Engine): sqlalchemy.Engine for DB connection
+        input (list[str]): List of strings that represent the iRODS paths
+
+    Returns:
+        num_update, nul_skipped, num_failed: Respectively, the number of iRODS paths
+            updated, skipped and failed during the metadata update
+    """
     num_updated = 0
     num_skipped = 0
     num_failed = 0

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -33,7 +33,7 @@ from npg_irods.db.mlwh import Sample, session_context
 
 from partisan.irods import make_rods_item, RodsError
 
-from npg_irods.metadata.common import avu_if_value
+from npg_irods.metadata.common import AVU
 from npg_irods.metadata.lims import TrackedSample
 
 description = """
@@ -113,19 +113,11 @@ def add_lims_uuid_to_iRODS_object(path: str, mlwh_session):
                 continue
 
             avu_to_add = [
-                [TrackedSample.LIMS, results[0].id_lims],
-                [TrackedSample.UUID, results[0].uuid_sample_lims],
+                AVU(TrackedSample.LIMS, results[0].id_lims),
+                AVU(TrackedSample.UUID, results[0].uuid_sample_lims),
             ]
-            no_null_avus = [
-                avu for avu in starmap(avu_if_value, avu_to_add) if avu is not None
-            ]
-            if len(avu_to_add) > len(no_null_avus):
-                msg = f"Possible NULL values in MLWH for {TrackedSample.LIMS} or {TrackedSample.UUID} for {iobj}"
-                log.warning(msg)
-                statuses.extend([Status.FAILED] * num_avu_to_add)
-                continue
 
-            for av in no_null_avus:
+            for av in avu_to_add:
                 num_avu_added = iobj.add_metadata(av)
                 if num_avu_added == 1:
                     statuses.append(Status.UPDATED)

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -124,7 +124,7 @@ def add_lims_uuid_to_iRODS_object(path: str, mlwh_session):
                     try:
                         irods_avu = iobj.avu(mlwh_avu.attribute)
                         if irods_avu.value != mlwh_avu.value:
-                            msg = f"Mismatch in {mlwh_avu.attribute} found between MLWH and iRODS for sample ID: {sample_id_avu.value}"
+                            msg = f"Mismatch in {mlwh_avu.attribute} found between MLWH and iRODS for sample ID: {sample_id_avu.value} on {iobj}"
                             log.error(msg)
                             statuses.append(Status.FAILED)
                             continue

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -192,6 +192,9 @@ def main():
         open(file=args.summary, mode="w") if args.summary is not None else None
     )
 
+    tot_updated = 0
+    tot_skipped = 0
+    tot_failed = 0
     with session_context(engine) as mlwh_session:
         for path in args.input:
             raw_path = path.strip()
@@ -209,6 +212,10 @@ def main():
                     case Status.FAILED:
                         num_failed += 1
 
+            tot_updated += num_updated
+            tot_skipped += num_skipped
+            tot_failed += num_failed
+
             if summary_file:
                 print(
                     raw_path,
@@ -225,15 +232,15 @@ def main():
     if num_failed:
         log.error(
             "Update failed",
-            num_updated=num_updated,
-            num_skipped=num_skipped,
-            num_errors=num_failed,
+            num_updated=tot_updated,
+            num_skipped=tot_skipped,
+            num_errors=tot_failed,
         )
         sys.exit(1)
 
     msg = "All updates were successful" if num_updated else "No updates were required"
     log.info(
         msg,
-        num_updated=num_updated,
-        num_skipped=num_skipped,
+        num_updated=tot_updated,
+        num_skipped=tot_skipped,
     )

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -56,6 +56,14 @@ def main():
         default=sys.stdin,
     )
     parser.add_argument(
+        "--db_section",
+        "--db-section",
+        help="Input file",
+        type=str,
+        choices=["mlwh_ro", "github"],
+        default="mlwh_ro",
+    )
+    parser.add_argument(
         "--version",
         help="Print the version and exit.",
         action="version",
@@ -72,7 +80,7 @@ def main():
     )
     add_appinfo_structlog_processor()
 
-    dbconfig = IniData(db.Config).from_file(args.db_config.name, "github")
+    dbconfig = IniData(db.Config).from_file(args.db_config.name, args.db_section)
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -175,7 +175,7 @@ def main():
         debug=args.debug,
         verbose=args.verbose,
         colour=args.colour,
-        json=args.json,
+        json=args.log_json,
     )
     add_appinfo_structlog_processor()
 

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2025 Genome Research Ltd. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+from itertools import starmap
+import sys
+
+import sqlalchemy
+from sqlalchemy.exc import SQLAlchemyError
+import structlog
+from npg.cli import add_db_config_arguments, add_io_arguments, add_logging_arguments
+from npg.conf import IniData
+from npg.log import configure_structlog
+
+from npg_irods import add_appinfo_structlog_processor, db, version
+
+from npg_irods.common import update_metadata
+from npg_irods.db.mlwh import Sample, session_context
+
+from partisan.irods import make_rods_item, RodsError
+
+from npg_irods.metadata.common import avu_if_value
+from npg_irods.metadata.lims import TrackedSample
+
+description = """
+"""
+
+
+log = structlog.get_logger("main")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=description, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    add_logging_arguments(parser)
+    add_db_config_arguments(parser)
+    parser.add_argument(
+        "--input",
+        help="Input file",
+        type=argparse.FileType("r", encoding="UTF-8"),
+        default=sys.stdin,
+    )
+    parser.add_argument(
+        "--version",
+        help="Print the version and exit.",
+        action="version",
+        version=version(),
+    )
+
+    args = parser.parse_args()
+    configure_structlog(
+        config_file=args.log_config,
+        debug=args.debug,
+        verbose=args.verbose,
+        colour=args.colour,
+        json=args.json,
+    )
+    add_appinfo_structlog_processor()
+
+    dbconfig = IniData(db.Config).from_file(args.db_config.name, "docker")
+    engine = sqlalchemy.create_engine(
+        dbconfig.url, pool_pre_ping=True, pool_recycle=3600
+    )
+    num_updated = 0
+    num_skipped = 0
+    num_failed = 0
+    with session_context(engine) as mlwh_session:
+        for path in args.input:
+            try:
+                iobj = make_rods_item(path.strip())
+                if not iobj.has_metadata_attrs(TrackedSample.ID):
+                    msg = f"No Sample ID attribute ({TrackedSample.ID}) found on {iobj}"
+                    log.warning(msg)
+                    num_skipped += 1
+                    continue
+
+                sample_id_avu = iobj.avu(TrackedSample.ID)
+
+                query = mlwh_session.query(Sample).filter(
+                    Sample.id_sample_lims == sample_id_avu.value,
+                )
+                results = query.all()
+                record_count = len(results)
+                if record_count == 0:
+                    msg = f"No record found for sample ID: {sample_id_avu.value}"
+                    log.error(msg)
+                    num_skipped += 1
+                    continue
+                if record_count > 1:
+                    msg = f"Multiple records found for sample ID: {sample_id_avu.value}"
+                    log.error(msg)
+                    num_skipped += 1
+                    continue
+
+                lims_ok = iobj.has_metadata_attrs([TrackedSample.LIMS])
+                uuid_ok = iobj.has_metadata_attrs([TrackedSample.UUID])
+                avu_to_add = []
+                if lims_ok:
+                    msg = f"Sample LIMS attribute ({TrackedSample.LIMS}) already found on {iobj}"
+                    log.warning(msg)
+                else:
+                    avu_to_add.append([TrackedSample.LIMS, results[0].id_lims])
+
+                if uuid_ok:
+                    msg = f"Sample UUID attribute ({TrackedSample.UUID}) already found on {iobj}"
+                    log.warning(msg)
+                else:
+                    avu_to_add.append([TrackedSample.UUID, results[0].uuid_sample_lims])
+
+                if lims_ok and uuid_ok:
+                    num_skipped += 1
+                    continue
+
+                avus = [
+                    avu for avu in starmap(avu_if_value, avu_to_add) if avu is not None
+                ]
+                if not avus:
+                    msg = f"Possible NULL values for {TrackedSample.LIMS} or {TrackedSample.UUID} on {iobj}"
+                    log.warning(msg)
+                    continue
+
+                meta_update = update_metadata(iobj, avus)
+                if meta_update:
+                    num_updated += 1
+                else:
+                    num_skipped += 1
+
+            except RodsError as re:
+                num_failed += 1
+                log.error(re.message, item=iobj, code=re.code)
+            except SQLAlchemyError as se:
+                num_failed += 1
+                log.error(se, item=iobj)
+                sys.exit(1)
+            except Exception as e:
+                num_failed += 1
+                log.error(e, item=iobj)
+
+    if num_failed:
+        log.error(
+            "Update failed",
+            num_updated=num_updated,
+            num_skipped=num_skipped,
+            num_errors=num_failed,
+        )
+        sys.exit(1)
+
+    msg = "All updates were successful" if num_updated else "No updates were required"
+    log.info(
+        msg,
+        num_updated=num_updated,
+        num_skipped=num_skipped,
+    )

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -72,7 +72,7 @@ def main():
     )
     add_appinfo_structlog_processor()
 
-    dbconfig = IniData(db.Config).from_file(args.db_config.name, "docker")
+    dbconfig = IniData(db.Config).from_file(args.db_config.name, "github")
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )

--- a/src/npg_irods/cli/update_uuid_lims_metadata.py
+++ b/src/npg_irods/cli/update_uuid_lims_metadata.py
@@ -19,7 +19,9 @@ import argparse
 from itertools import starmap
 import sys
 
+from sqlalchemy import Engine
 import sqlalchemy
+from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 import structlog
 from npg.cli import add_db_config_arguments, add_io_arguments, add_logging_arguments
@@ -37,10 +39,102 @@ from npg_irods.metadata.common import avu_if_value
 from npg_irods.metadata.lims import TrackedSample
 
 description = """
+Add sample_lims and sample_uuid given a DataObject or Collection in input.
+The AVU is retrieved from the MLWH and added only if it is not present. 
+In particular, the metadata update is skipped when:
+    - Both AVUs are present
+    - One of the AVUs has NULL value in MLWH
+    - No sample_id has been found on the iRODS path
+    - No sample_id record is found in MLWH
+    - Multiple records have been found in MLWH with the sample_id from iRODS metadata
 """
 
 
 log = structlog.get_logger("main")
+
+
+def add_lims_uuid_from_input(engine: Engine, input):
+    num_updated = 0
+    num_skipped = 0
+    num_failed = 0
+    with session_context(engine) as mlwh_session:
+        for path in input:
+            try:
+                iobj = make_rods_item(path.strip())
+                if not iobj.has_metadata_attrs(TrackedSample.ID):
+                    msg = f"No Sample ID attribute ({TrackedSample.ID}) found on {iobj}"
+                    log.info(msg)
+                    num_skipped += 1
+                    continue
+
+                sample_id_avu = iobj.avu(TrackedSample.ID)
+
+                query = mlwh_session.query(Sample).filter(
+                    Sample.id_sample_lims == sample_id_avu.value,
+                )
+                results = query.all()
+                record_count = len(results)
+                if record_count == 0:
+                    msg = f"No record found for sample ID: {sample_id_avu.value}"
+                    log.error(msg)
+                    num_skipped += 1
+                    continue
+                if record_count > 1:
+                    msg = f"Multiple records found for sample ID: {sample_id_avu.value}"
+                    log.error(msg)
+                    num_skipped += 1
+                    continue
+
+                lims_ok = iobj.has_metadata_attrs([TrackedSample.LIMS])
+                uuid_ok = iobj.has_metadata_attrs([TrackedSample.UUID])
+                avu_to_add = []
+                if lims_ok:
+                    msg = f"Sample LIMS attribute ({TrackedSample.LIMS}) already found on {iobj}"
+                    log.info(msg)
+                else:
+                    avu_to_add.append([TrackedSample.LIMS, results[0].id_lims])
+
+                if uuid_ok:
+                    msg = f"Sample UUID attribute ({TrackedSample.UUID}) already found on {iobj}"
+                    log.info(msg)
+                else:
+                    avu_to_add.append([TrackedSample.UUID, results[0].uuid_sample_lims])
+
+                if lims_ok and uuid_ok:
+                    num_skipped += 1
+                    msg = (
+                        f"Both Sample UUID and LIMS attributes already found on {iobj}"
+                    )
+                    log.info(msg)
+                    continue
+
+                no_null_avus = [
+                    avu for avu in starmap(avu_if_value, avu_to_add) if avu is not None
+                ]
+                if len(avu_to_add) > len(no_null_avus):
+                    msg = f"Possible NULL values for {TrackedSample.LIMS} or {TrackedSample.UUID} on {iobj}"
+                    num_skipped += 1
+                    log.warning(msg)
+                    continue
+
+                num_avu_added = iobj.add_metadata(*no_null_avus)
+                if num_avu_added > 0:
+                    num_updated += 1
+                else:
+                    num_skipped += 1
+
+            except RodsError as re:
+                num_failed += 1
+                log.error(re.message, item=iobj, code=re.code)
+            except SQLAlchemyError as se:
+                num_failed += 1
+                log.error(se, item=iobj)
+                sys.exit(1)
+            except Exception as e:
+                num_failed += 1
+                log.error(e, item=iobj)
+
+    return num_updated, num_skipped, num_failed
 
 
 def main():
@@ -84,80 +178,8 @@ def main():
     engine = sqlalchemy.create_engine(
         dbconfig.url, pool_pre_ping=True, pool_recycle=3600
     )
-    num_updated = 0
-    num_skipped = 0
-    num_failed = 0
-    with session_context(engine) as mlwh_session:
-        for path in args.input:
-            try:
-                iobj = make_rods_item(path.strip())
-                if not iobj.has_metadata_attrs(TrackedSample.ID):
-                    msg = f"No Sample ID attribute ({TrackedSample.ID}) found on {iobj}"
-                    log.warning(msg)
-                    num_skipped += 1
-                    continue
 
-                sample_id_avu = iobj.avu(TrackedSample.ID)
-
-                query = mlwh_session.query(Sample).filter(
-                    Sample.id_sample_lims == sample_id_avu.value,
-                )
-                results = query.all()
-                record_count = len(results)
-                if record_count == 0:
-                    msg = f"No record found for sample ID: {sample_id_avu.value}"
-                    log.error(msg)
-                    num_skipped += 1
-                    continue
-                if record_count > 1:
-                    msg = f"Multiple records found for sample ID: {sample_id_avu.value}"
-                    log.error(msg)
-                    num_skipped += 1
-                    continue
-
-                lims_ok = iobj.has_metadata_attrs([TrackedSample.LIMS])
-                uuid_ok = iobj.has_metadata_attrs([TrackedSample.UUID])
-                avu_to_add = []
-                if lims_ok:
-                    msg = f"Sample LIMS attribute ({TrackedSample.LIMS}) already found on {iobj}"
-                    log.warning(msg)
-                else:
-                    avu_to_add.append([TrackedSample.LIMS, results[0].id_lims])
-
-                if uuid_ok:
-                    msg = f"Sample UUID attribute ({TrackedSample.UUID}) already found on {iobj}"
-                    log.warning(msg)
-                else:
-                    avu_to_add.append([TrackedSample.UUID, results[0].uuid_sample_lims])
-
-                if lims_ok and uuid_ok:
-                    num_skipped += 1
-                    continue
-
-                avus = [
-                    avu for avu in starmap(avu_if_value, avu_to_add) if avu is not None
-                ]
-                if not avus:
-                    msg = f"Possible NULL values for {TrackedSample.LIMS} or {TrackedSample.UUID} on {iobj}"
-                    log.warning(msg)
-                    continue
-
-                meta_update = update_metadata(iobj, avus)
-                if meta_update:
-                    num_updated += 1
-                else:
-                    num_skipped += 1
-
-            except RodsError as re:
-                num_failed += 1
-                log.error(re.message, item=iobj, code=re.code)
-            except SQLAlchemyError as se:
-                num_failed += 1
-                log.error(se, item=iobj)
-                sys.exit(1)
-            except Exception as e:
-                num_failed += 1
-                log.error(e, item=iobj)
+    num_updated, num_skipped, num_failed = add_lims_uuid_from_input(engine, args.input)
 
     if num_failed:
         log.error(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -395,6 +395,7 @@ def challenging_paths_irods(tmp_path):
 
 @pytest.fixture(scope="function")
 def connection_engine():
+    """A fixture providing a connection engine to DB"""
     config_file = Path("tests/testdb.ini")
     dbconfig = IniData(db.Config).from_file(config_file, "github")
     engine = sqlalchemy.create_engine(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,10 @@
 import logging
 import os
 from datetime import datetime, timezone
-from pathlib import PurePath
+from pathlib import Path, PurePath
 
 import pytest
+import sqlalchemy
 import structlog
 from npg.conf import IniData
 from partisan.icommands import (
@@ -390,3 +391,13 @@ def challenging_paths_irods(tmp_path):
         yield expt_root
     finally:
         remove_rods_path(rods_path)
+
+
+@pytest.fixture(scope="function")
+def connection_engine():
+    config_file = Path("tests/testdb.ini")
+    dbconfig = IniData(db.Config).from_file(config_file, "github")
+    engine = sqlalchemy.create_engine(
+        dbconfig.url, pool_pre_ping=True, pool_recycle=3600
+    )
+    return engine

--- a/tests/illumina/test_metadata_update.py
+++ b/tests/illumina/test_metadata_update.py
@@ -741,7 +741,7 @@ class TestIlluminaPermissionsUpdate:
         )
         assert obj.permissions() == new_permissions
 
-    @m.context("When the sample ID is in the metadata")
+    @m.context("When the sample_id is in the metadata")
     @m.context("When sample_uuid and sample_lims are not present")
     @m.it("Add sample_uuid and sample_lims")
     def test_add_sample_uuid_lims(
@@ -765,6 +765,8 @@ class TestIlluminaPermissionsUpdate:
                 "--db-config",
                 "tests/testdb.ini",
                 "--verbose",
+                "--db-section",
+                "github",
             ],
             stdin=echo_proc.stdout,
             stdout=subprocess.PIPE,

--- a/tests/illumina/test_metadata_update.py
+++ b/tests/illumina/test_metadata_update.py
@@ -943,13 +943,13 @@ class TestIlluminaPermissionsUpdate:
         path = illumina_synthetic_irods / "12345" / "12345.cram"
 
         obj = DataObject(path)
-        expected_metadata = [
+        expected_mismatching_metadata = [
             AVU(TrackedSample.ID, "id_sample_lims1"),
             AVU(TrackedSample.LIMS, "LIMS_05"),
             AVU(TrackedSample.UUID, "52429892-0ab6-11ee-b5ba-fa163eac3af5"),
         ]
-        obj.add_metadata(*expected_metadata)
-        for avu in expected_metadata:
+        obj.add_metadata(*expected_mismatching_metadata)
+        for avu in expected_mismatching_metadata:
             assert avu in obj.metadata()
 
         with session_context(connection_engine) as mlwh_session:

--- a/tests/ont/test_metadata_update.py
+++ b/tests/ont/test_metadata_update.py
@@ -46,11 +46,11 @@ from npg_irods.ont import (
     is_minknow_report,
 )
 from ont.conftest import ont_tag_identifier
-from src.npg_irods.cli.update_uuid_lims_metadata import (
+from npg_irods.cli.update_uuid_lims_metadata import (
     Status,
     add_lims_uuid_to_iRODS_object,
 )
-from src.npg_irods.db.mlwh import session_context
+from npg_irods.db.mlwh import session_context
 
 
 class TestONTFindUpdates:
@@ -581,8 +581,9 @@ class TestONTMetadataUpdate(object):
                 for md in [expected_lims, expected_uuid]:
                     assert md not in previous_metadata
 
-                status = add_lims_uuid_to_iRODS_object(str(bpath), mlwh_session)
-                assert status == Status.UPDATED
+                statuses = add_lims_uuid_to_iRODS_object(str(bpath), mlwh_session)
+                assert statuses.count(Status.UPDATED) == 2
+
                 actual_metadata = bcoll.metadata()
                 for md in [expected_lims, expected_uuid]:
                     assert md in actual_metadata


### PR DESCRIPTION
This is a non-mergeble PR. The back-population functionality will be used just once. This PR is open only to simplify the review and run all tests in CI.

Add **_sample_lims_** and **_sample_uuid_** given a list of DataObjects or Collections in input with **_sample_id_**.
Each AVU is retrieved from the MLWH and added only if it is not present. 
In particular, the AVU addition is avoided when:
    - The AVU is present (Skipped)
    - One of the AVU has NULL value in MLWH (Failed)
    - No sample_id has been found on the iRODS path (Failed)
    - No sample_id record is found in MLWH (Failed)
    - Multiple records have been found in MLWH with the sample_id from iRODS metadata (Failed)