### PR TITLE
Enhance publish-directory (add --include-top-level-files and --exclude-md5)

### DIFF
--- a/src/npg_irods/cli/publish_directory.py
+++ b/src/npg_irods/cli/publish_directory.py
@@ -20,6 +20,7 @@
 import argparse
 import json
 import sys
+from pathlib import Path
 
 import structlog
 from npg.cli import add_logging_arguments, integer_in_range
@@ -65,6 +66,7 @@ parser.add_argument(
     action="append",
     default=[],
 )
+
 parser.add_argument(
     "--include",
     help="Include paths matching the given regular expression. Only matching "
@@ -76,6 +78,26 @@ parser.add_argument(
     type=str,
     action="append",
     default=[],
+)
+
+
+# Provide convenience method for common use case of --exclude.
+# We often need to apply permissions and metadata to the files in root of a run
+# differently from sample folders.
+# We had several bugs in ultimagen_publish_to_irods.py from rnd_platforms
+# due to issues filtering to just top level files using approach of excluding
+# sample folders with a regular expression.
+parser.add_argument(
+    "--include-top-level-files",
+    help="Include top level files. Composes with other filters.",
+    action="store_true",
+)
+
+# Provide convenience method for common use case of --exclude.
+parser.add_argument(
+    "--exclude-md5",
+    help="Exclude md5 files. Composes with other filters.",
+    action="store_true",
 )
 
 ff_group = parser.add_mutually_exclusive_group(required=False)
@@ -194,8 +216,17 @@ def main():
     )
 
     filter_fn = (
-        make_path_filter(include_patterns=args.include, exclude_patterns=args.exclude)
-        if args.exclude or args.include
+        make_path_filter(
+            include_patterns=args.include,
+            exclude_patterns=args.exclude,
+            include_top_level_files=args.include_top_level_files,
+            exclude_md5=args.exclude_md5,
+            src=Path(args.directory),
+        )
+        if args.exclude
+        or args.include
+        or args.include_top_level_files
+        or args.exclude_md5
         else None
     )
 

--- a/src/npg_irods/functions.py
+++ b/src/npg_irods/functions.py
@@ -27,33 +27,56 @@ from structlog.stdlib import get_logger
 log = get_logger(__name__)
 
 
+def _is_top_level_file(path: Path, parent: Path):
+    if not path.is_file():
+        return False
+
+    path_absolute = path.resolve()
+    parent_absolute = parent.resolve()
+
+    return path_absolute.parent == parent_absolute
+
+
 def make_path_filter(
     include_patterns: list[str] = None,
     exclude_patterns: list[str] = None,
+    include_top_level_files: bool = False,
+    exclude_md5: bool = False,
+    src: Path | None = None,
     flags: int | re.RegexFlag = 0,
 ):
-    """Return a function that filters paths based on the given regex patterns.
+    """Return a function that filters paths based on the given filters.
 
     Args:
         include_patterns: Include paths matching the given regular expressions.
         exclude_patterns: Exclude paths matching the given regular expressions.
             Exclude applied after include.
+        include_top_level_files: Include files immediately below top level directory.
+        exclude_md5: Exclude md5 files.
+        src: Top level directory to compare against for include_top_level_files. Required if include_top_level_files=True.
         flags: Optional regex flags to use when compiling the patterns.
 
     Returns:
         A function that accepts a Path and returns True if the path doesn't
-        match any of the include patterns or matches any of the exclude
-        patterns, False otherwise.
+        match any of the include filters or matches any of the exclude
+        filters, False otherwise.
     """
+    if include_top_level_files and not src:
+        raise ValueError("`src` is required if when `include_top_level_files` is True")
+
     include_patterns = include_patterns or []
     exclude_patterns = exclude_patterns or []
 
     include_regexes = [re.compile(p, flags=flags) for p in include_patterns]
     exclude_regexes = [re.compile(p, flags=flags) for p in exclude_patterns]
 
+    if exclude_md5:
+        exclude_regexes.append(re.compile(".md5"))
+
     def path_filter(path: Path) -> bool:
-        if include_regexes:
+        if include_regexes or include_top_level_files:
             include = False
+
             for r in include_regexes:
                 if r.search(path.as_posix()):
                     log.debug(
@@ -64,6 +87,12 @@ def make_path_filter(
                     )
                     include = True
                     break
+
+            if include_top_level_files:
+                if _is_top_level_file(path, src):
+                    log.debug("Filtering path", path=path, is_top_level_file=True)
+                    include = True
+
             if not include:
                 return True
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from pytest import mark as m
+from pytest import MonkeyPatch
 
 from npg_irods.functions import make_path_filter
 
@@ -34,10 +35,10 @@ class TestMakePathFilter:
 
         # Act
         filter_fn = make_path_filter(exclude_patterns=["1", "2"])
-        filtered = [x for x in paths if filter_fn is None or not filter_fn(x)]
+        filtered = set(x for x in paths if filter_fn is None or not filter_fn(x))
 
         # Assert
-        assert filtered == [Path("a3b")]
+        assert filtered == {Path("a3b")}
 
     @m.context("With include pattern")
     @m.it("Include items that match filter anywhere in path")
@@ -47,10 +48,10 @@ class TestMakePathFilter:
 
         # Act
         filter_fn = make_path_filter(include_patterns=["1", "2"])
-        filtered = [x for x in paths if filter_fn is None or not filter_fn(x)]
+        filtered = set(x for x in paths if filter_fn is None or not filter_fn(x))
 
         # Assert
-        assert filtered == [Path("a1b"), Path("a2b")]
+        assert filtered == {Path("a1b"), Path("a2b")}
 
     @m.context("When include and exclude patterns provided")
     @m.it("Should compose filters")
@@ -72,7 +73,46 @@ class TestMakePathFilter:
         filter_fn = make_path_filter(
             include_patterns=["1", "2"], exclude_patterns=["X", "Y"]
         )
-        filtered = [x for x in paths if filter_fn is None or not filter_fn(x)]
+        filtered = set(x for x in paths if filter_fn is None or not filter_fn(x))
 
         # Assert
-        assert filtered == [Path("a1Zb"), Path("a2Zb")]
+        assert filtered == {Path("a1Zb"), Path("a2Zb")}
+
+    @m.context("With include top level files option")
+    @m.it("Includes top level files")
+    def test_include_top_level_files(self, monkeypatch: MonkeyPatch):
+        # Arrange
+        monkeypatch.chdir(Path("./tests/data/ultima/minimal"))
+        paths = list(Path(".").rglob("*"))
+
+        # Act
+        filter_fn = make_path_filter(include_top_level_files=True, src=Path("."))
+        filtered = set(x for x in paths if filter_fn is None or not filter_fn(x))
+
+        # Assert
+        assert filtered == {
+            Path("000001_a.txt"),
+            Path("000001_a.txt.md5"),
+            Path("b.txt"),
+            Path("b.txt.md5"),
+        }
+
+    @m.context("With exclude MD5 option")
+    @m.it("Excludes md5 files")
+    def test_exclude_md5(self, monkeypatch: MonkeyPatch):
+        # Arrange
+        monkeypatch.chdir(Path("./tests/data/ultima/minimal"))
+        paths = list(Path(".").rglob("*"))
+
+        # Act
+        filter_fn = make_path_filter(exclude_md5=True)
+        filtered = set(x for x in paths if filter_fn is None or not filter_fn(x))
+
+        # Assert
+        assert filtered == {
+            Path("000001_a.txt"),
+            Path("b.txt"),
+            Path("000001-a"),
+            Path("000001-a/000002-c.txt"),
+        }
+        filtered = [x for x in paths if filter_fn is None or not filter_fn(x)]


### PR DESCRIPTION
`--include-top-level-files`

Provides convenience method for common use case of --exclude.
We often need to apply permissions and metadata to the files in root of a run differently from sample folders.
We had several bugs in ultimagen_publish_to_irods.py from rnd_platforms due to issues filtering to just top level files using approach of excluding sample folders with a regular expression.

`--exclude-md5`

Provide convenience method for common use case of --exclude. Simplifies testing of callers. More marginal benefit than `--include-top-level-files`, happy to leave out.

