### PR TITLE
Add sqlite to deployment container

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.13", "3.14" ]
         irods: [
           { version: "4.2.7",
             client_image: "ghcr.io/wtsi-npg/ub-16.04-irods-clients-4.2.7:latest",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 ubuntu:bionic AS builder
 
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.14
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -8,14 +8,17 @@ RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     autoconf \
     automake \
-    build-essential \
     ca-certificates \
     curl \
     git \
     libtool \
+    make \
     pkg-config \
-    libffi-dev \
     libbz2-dev \
+    libffi-dev \
+    libncurses-dev \
+    libsqlite3-dev \
+    libreadline-dev \
     libssl-dev \
     zlib1g-dev \
     unattended-upgrades && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,13 +10,15 @@ RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-transport-https \
     apt-utils \
-    build-essential \
     ca-certificates \
     curl \
     gcc \
     git \
+    libtool \
     make \
+    pkg-config \
     libbz2-dev \
+    libffi-dev \
     libncurses-dev \
     libsqlite3-dev \
     libreadline-dev \


### PR DESCRIPTION
The deployment container was build without the require SQLite support for Python.

Move deployment container from Python 3.12 to 3.14.

Tidy up the OS packages used for builds so that the dev and deployment containers are more consistent with each other.