### PR TITLE
Minor checksum-directory improvements

### DIFF
--- a/src/npg_irods/checksum.py
+++ b/src/npg_irods/checksum.py
@@ -45,7 +45,9 @@ def checksum_directory(path: Path, md5sums_path: Path):
 
     md5sums = read_md5sums_file(md5sums_path) if md5sums_path.exists() else {}
 
-    with md5sums_path.open("a") as md5sums_file:
+    # Use line buffering so checksums we've already calculated are persisted even
+    # if something goes wrong.
+    with md5sums_path.open("a", buffering=1) as md5sums_file:
         for path in sorted(path.rglob("*")):
             if path.is_file() and path.suffix.lower() != ".md5":
                 num_files += 1

--- a/src/npg_irods/checksum.py
+++ b/src/npg_irods/checksum.py
@@ -53,7 +53,7 @@ def checksum_directory(path: Path, md5sums_path: Path):
                 num_files += 1
 
                 if path in md5sums:
-                    log.debug(
+                    log.info(
                         "Match found in md5sums file. Skipping.",
                         path=path,
                         md5sums_path=md5sums_path,
@@ -66,7 +66,7 @@ def checksum_directory(path: Path, md5sums_path: Path):
                 md5sum = digest.hexdigest()
                 md5sums_file.write(f"{md5sum}  {path}\n")
 
-                log.debug("Calculated checksum.", path=path, md5sum=md5sum)
+                log.info("Calculated checksum.", path=path, md5sum=md5sum)
 
                 num_checksummed += 1
 


### PR DESCRIPTION
- Use line buffering so checksums we've already calculated are persisted even if something goes wrong.
- Output progress when run with --verbose, match partisan