### PR TITLE
checksum-directory, publish-xenium-results: Introduce checksums folder mode

### DIFF
--- a/src/npg_irods/checksum.py
+++ b/src/npg_irods/checksum.py
@@ -45,6 +45,10 @@ def checksum_directory(path: Path, md5sums_path: Path):
 
     md5sums = read_md5sums_file(md5sums_path) if md5sums_path.exists() else {}
 
+    # Need to ensure parent directories of checksum file exist in --use-checksum-directory
+    # case because checksum-directory responsible for calculating the path.
+    md5sums_path.parent.mkdir(parents=True, exist_ok=True)
+
     with md5sums_path.open("a") as md5sums_file:
         for path in sorted(path.rglob("*")):
             if path.is_file() and path.suffix.lower() != ".md5":

--- a/src/npg_irods/checksum.py
+++ b/src/npg_irods/checksum.py
@@ -23,14 +23,14 @@ from pathlib import Path
 from npg_irods.utilities import read_md5sums_file, log
 
 
-def checksum_directory(path: Path, md5sums_path: Path):
+def checksum_directory(directory_path: Path, md5sums_path: Path):
     """Calculate MD5 checksums for all files in a directory and write to file.
 
     The output follows GNU coreutils md5sum format. Checksum files (*.md5) are
     ignored. Files with existing checksums are skipped.
 
     Args:
-        path (Path): The directory to checksum.
+        directory_path (Path): The directory to checksum.
         md5sums_path (Path): The file to write checksums to.
 
     Returns:
@@ -41,7 +41,7 @@ def checksum_directory(path: Path, md5sums_path: Path):
     num_files = 0
     num_checksummed = 0
 
-    path = path.resolve()
+    directory_path = directory_path.resolve()
 
     md5sums = read_md5sums_file(md5sums_path) if md5sums_path.exists() else {}
 
@@ -50,25 +50,31 @@ def checksum_directory(path: Path, md5sums_path: Path):
     md5sums_path.parent.mkdir(parents=True, exist_ok=True)
 
     with md5sums_path.open("a") as md5sums_file:
-        for path in sorted(path.rglob("*")):
-            if path.is_file() and path.suffix.lower() != ".md5":
+        for file_path in sorted(directory_path.rglob("*")):
+            if file_path.is_file() and file_path.suffix.lower() != ".md5":
                 num_files += 1
 
-                if path in md5sums:
+                if file_path in md5sums:
                     log.debug(
                         "Match found in md5sums file. Skipping.",
-                        path=path,
+                        path=file_path,
                         md5sums_path=md5sums_path,
                     )
                     continue
 
-                with open(path, "rb") as f:
+                if file_path.is_symlink():
+                    # We've encountered symbolic links to device files e.g. /proc/kcore
+                    # Filter out
+                    log.warn("Path is a symbolic link. Skipping.", path=file_path)
+                    continue
+
+                with open(file_path, "rb") as f:
                     digest = file_digest(f, "md5")
 
                 md5sum = digest.hexdigest()
-                md5sums_file.write(f"{md5sum}  {path}\n")
+                md5sums_file.write(f"{md5sum}  {file_path}\n")
 
-                log.debug("Calculated checksum.", path=path, md5sum=md5sum)
+                log.debug("Calculated checksum.", path=file_path, md5sum=md5sum)
 
                 num_checksummed += 1
 

--- a/src/npg_irods/cli/checksum_directory.py
+++ b/src/npg_irods/cli/checksum_directory.py
@@ -29,12 +29,17 @@ from npg_irods.checksum import checksum_directory
 from npg_irods.utilities import get_md5sums_path
 
 description = """
-BOB
-
 A utility to calculate MD5 checksums for all files in a directory.
 
 The output follows GNU coreutils md5sum format. Checksum files (*.md5) are
 ignored. Files with existing checksums are skipped.
+
+Supports two modes of specifying checksum locations:
+
+- Explicitly specifying a file to write checksums to (`--md5sums-path`)
+- Specifying a directory (`--checksums-directory`). Checksums are written to a
+  file within the directory that can be uniquely retrieved by other
+  npg-irods-python utilities.
 """
 
 
@@ -65,8 +70,8 @@ def main():
     checksums_file_group.add_argument(
         "--checksums-directory",
         help="The directory to write checksums to."
-        "The path of file to write checksums to is derived from path of"
-        "directory to checksum.",
+        "The path of the file to write checksums to is derived from the path of"
+        "the directory to checksum.",
     )
 
     parser.add_argument(

--- a/src/npg_irods/cli/checksum_directory.py
+++ b/src/npg_irods/cli/checksum_directory.py
@@ -26,8 +26,11 @@ from npg.log import configure_structlog
 
 from npg_irods import add_appinfo_structlog_processor, version
 from npg_irods.checksum import checksum_directory
+from npg_irods.utilities import get_md5sums_path
 
 description = """
+BOB
+
 A utility to calculate MD5 checksums for all files in a directory.
 
 The output follows GNU coreutils md5sum format. Checksum files (*.md5) are
@@ -51,10 +54,19 @@ def main():
         type=str,
     )
 
-    parser.add_argument(
+    checksums_file_group = parser.add_mutually_exclusive_group(required=True)
+
+    checksums_file_group.add_argument(
         "--md5sums-path",
         help="The file to write checksums to.",
         type=str,
+    )
+
+    checksums_file_group.add_argument(
+        "--checksums-directory",
+        help="The directory to write checksums to."
+        "The path of file to write checksums to is derived from path of"
+        "directory to checksum.",
     )
 
     parser.add_argument(
@@ -75,7 +87,17 @@ def main():
     add_appinfo_structlog_processor()
 
     path = Path(args.directory)
-    md5sums_path = Path(args.md5sums_path)
+
+    if args.md5sums_path:
+        md5sums_path = Path(args.md5sums_path)
+    elif args.checksums_directory:
+        md5sums_path = get_md5sums_path(Path(args.checksums_directory), path)
+    else:
+        raise ValueError(
+            "Expected an md5sums path or a checksums directory to be specified."
+        )
+
+    logger().info("Checksumming directory", directory=path, md5sums=md5sums_path)
 
     num_files, num_checksummed = checksum_directory(
         path,
@@ -83,7 +105,7 @@ def main():
     )
 
     logger().info(
-        "Checksummed path successfully",
+        "Checksummed directory successfully",
         num_files=num_files,
         num_checksummed=num_checksummed,
     )

--- a/src/npg_irods/cli/publish_directory.py
+++ b/src/npg_irods/cli/publish_directory.py
@@ -25,13 +25,13 @@ from typing import Callable
 import structlog
 from npg.cli import add_logging_arguments, integer_in_range
 from npg.log import configure_structlog
-from partisan.irods import AC, AVU, Permission, current_user
+from partisan.irods import AC, AVU, Permission
 
 from npg_irods import add_appinfo_structlog_processor
 from npg_irods.common import infer_zone
 from npg_irods.functions import make_path_filter
 from npg_irods.publish import publish_directory
-from npg_irods.utilities import read_md5_file, read_md5sums_file
+from npg_irods.utilities import read_md5_file, make_get_checksum
 
 description = """
 A utility to (recursively) publish a local directory to iRODS, retaining the directory
@@ -41,26 +41,6 @@ structure.
 
 def logger():
     return structlog.get_logger(__name__)
-
-
-def make_get_checksum(md5sums_path: Path) -> Callable[[Path | str], str]:
-    md5sums = read_md5sums_file(md5sums_path)
-    md5sums_modified = md5sums_path.stat().st_mtime
-
-    def get_checksum(path: Path | str) -> str:
-        path = Path(path) if isinstance(path, str) else path
-        path = path.resolve()
-        checksum = md5sums.get(path)
-        if not checksum:
-            raise ValueError(f"No checksum found for {path}")
-        path_modified = path.stat().st_mtime
-        if path_modified > md5sums_modified:
-            raise ValueError(
-                f"Checksum for {path} may be out of date, file modified ({path_modified}) more recently than {md5sums_path} ({md5sums_modified})"
-            )
-        return checksum
-
-    return get_checksum
 
 
 def _parse_group(group: str) -> tuple[str, str | None]:

--- a/src/npg_irods/cli/publish_xenium_results.py
+++ b/src/npg_irods/cli/publish_xenium_results.py
@@ -17,6 +17,7 @@
 #
 import argparse
 import sys
+from pathlib import Path
 
 import structlog
 from npg.cli import add_io_arguments, add_logging_arguments, open_input, open_output
@@ -70,6 +71,16 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "--use-checksums-directory",
+        help="Expect checksums to be present in a checksums file within specified "
+        "checksums directory following GNU coreutils md5sum format. "
+        "This avoids having to calculate the checksums during the publish process. "
+        "If this option is enabled and a checksum is missing or stale, an error "
+        "will be raised for that file. "
+        "Optional, defaults to none.",
+        type=str,
+    )
+    parser.add_argument(
         "--version",
         help="Print the version and exit.",
         action="version",
@@ -88,6 +99,9 @@ def main():
 
     input_path = sanitise_path(args.input)
     output_path = sanitise_path(args.output)
+    checksums_directory = (
+        Path(args.use_checksums_directory) if args.use_checksums_directory else None
+    )
 
     with open_input(input_path, encoding="utf-8") as reader:
         with open_output(output_path, encoding="utf-8") as writer:
@@ -98,6 +112,7 @@ def main():
                 remote_root=args.collection,
                 print_success=args.print_success,
                 print_fail=args.print_fail,
+                use_checksums_directory=checksums_directory,
             )
 
             if num_failed:

--- a/src/npg_irods/utilities.py
+++ b/src/npg_irods/utilities.py
@@ -1262,17 +1262,15 @@ def read_md5_file(path: Path) -> str:
 
 def get_md5sums_path(checksums_directory: Path, folder: Path) -> Path:
     """
-    TODO: incl only one implementation
+    Returns a path to checksums file for given folder.
 
-    Note: provides a default implementation of organising a checksums directory.
+    Guarantees checksums file will be unique for the folder by using the full
+    folder path to generate path.
 
-    Individual instrument pipelines may want a different implementation, e.g.
-    - Using jus
-    - Sharding
+    Individual instrument pipelines may have different requirements (e.g. sharding,
+    not requiring full path to be used for uniqueness) and need to calculate a path
+    themselves.
     """
-
-    # TODO: Consider sharding?
-
     return (checksums_directory.resolve() / folder.relative_to("/")).with_suffix(".md5")
 
 

--- a/src/npg_irods/utilities.py
+++ b/src/npg_irods/utilities.py
@@ -33,6 +33,7 @@ import unicodedata
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from importlib import resources
 from pathlib import Path, PurePath
+from typing import Callable
 
 import partisan
 from partisan.exception import RodsError
@@ -1259,6 +1260,22 @@ def read_md5_file(path: Path) -> str:
         return md5
 
 
+def get_md5sums_path(checksums_directory: Path, folder: Path) -> Path:
+    """
+    TODO: incl only one implementation
+
+    Note: provides a default implementation of organising a checksums directory.
+
+    Individual instrument pipelines may want a different implementation, e.g.
+    - Using jus
+    - Sharding
+    """
+
+    # TODO: Consider sharding?
+
+    return (checksums_directory.resolve() / folder.relative_to("/")).with_suffix(".md5")
+
+
 def read_md5sums_file(path: Path) -> dict[Path, str]:
     """
     Reads an MD5 checksums file produced by checksum-directory or another tool
@@ -1281,6 +1298,32 @@ def read_md5sums_file(path: Path) -> dict[Path, str]:
                 raise ValueError(f"MD5 checksum is not 32 characters: '{md5}'")
             md5sums[Path(path)] = md5
     return md5sums
+
+
+def make_get_checksum(md5sums_path: Path) -> Callable[[Path | str], str]:
+    md5sums = read_md5sums_file(md5sums_path)
+    md5sums_modified = md5sums_path.stat().st_mtime
+
+    def get_checksum(path: Path | str) -> str:
+        path = Path(path) if isinstance(path, str) else path
+        path = path.resolve()
+        checksum = md5sums.get(path)
+        if not checksum:
+            raise ValueError(f"No checksum found for {path}")
+        path_modified = path.stat().st_mtime
+        if path_modified > md5sums_modified:
+            raise ValueError(
+                f"Checksum for {path} may be out of date, file modified ({path_modified}) more recently than {md5sums_path} ({md5sums_modified})"
+            )
+        log.debug(
+            "Read checksum from checksums file",
+            local_checksum=checksum,
+            path=path,
+            md5sums_path=md5sums_path,
+        )
+        return checksum
+
+    return get_checksum
 
 
 def sanitise_path(path: str | None) -> str | None:

--- a/src/npg_irods/xenium.py
+++ b/src/npg_irods/xenium.py
@@ -108,13 +108,16 @@ def publish_result_dirs(
         try:
             publish_result_dir(p, remote_root)
 
+            num_published += 1
+
             if print_success:
-                num_published += 1
                 print(p, file=writer)
         except Exception as e:
             log.error(f"Failed to publish '{p}': {e}")
+
+            number_failed += 1
+
             if print_fail:
-                number_failed += 1
                 print(p, file=writer)
 
     return num_dirs, num_published, number_failed

--- a/src/npg_irods/xenium.py
+++ b/src/npg_irods/xenium.py
@@ -99,7 +99,7 @@ def publish_result_dirs(
             to True.
         print_fail: Print the paths of directories that failed to publish. Defaults
             to False.
-        use_checksums_directory: TODO
+        use_checksums_directory: Path to checksum directory. Optional.
 
     Returns:
         A tuple of the number of directories processed, the number successfully
@@ -145,7 +145,7 @@ def publish_result_dir(
         remote_root: iRODS path to the root of the Xenium results collection. This
             collection must exist.
         tries: Number of times to retry publishing if it fails.
-        use_checksums_directory: TODO
+        use_checksums_directory: Path to checksum directory. Optional.
 
     Returns:
         The iRODS collection containing the published results.

--- a/src/npg_irods/xenium.py
+++ b/src/npg_irods/xenium.py
@@ -18,6 +18,7 @@
 
 import json
 from pathlib import Path, PurePath
+from typing import Callable
 
 from partisan.irods import AVU, Collection
 from structlog import get_logger
@@ -26,7 +27,7 @@ from npg_irods.common import PlatformNamespace
 from npg_irods.exception import PublishingError
 from npg_irods.metadata.xenium import EXPERIMENT_FILENAME, Instrument
 from npg_irods.publish import publish_directory
-from npg_irods.utilities import sanitise_path
+from npg_irods.utilities import sanitise_path, get_md5sums_path, make_get_checksum
 
 log = get_logger(__name__)
 
@@ -73,7 +74,12 @@ def make_xenium_metadata(result_dir: Path) -> list[AVU]:
 
 
 def publish_result_dirs(
-    reader, writer, remote_root: PurePath, print_success=True, print_fail=False
+    reader,
+    writer,
+    remote_root: PurePath,
+    print_success=True,
+    print_fail=False,
+    use_checksums_directory: Path | None = None,
 ):
     """Read local Xenium result directory paths from a reader and publish their contents
     to iRODS, printing the results to a writer.
@@ -93,6 +99,7 @@ def publish_result_dirs(
             to True.
         print_fail: Print the paths of directories that failed to publish. Defaults
             to False.
+        use_checksums_directory: TODO
 
     Returns:
         A tuple of the number of directories processed, the number successfully
@@ -106,7 +113,9 @@ def publish_result_dirs(
 
         num_dirs += 1
         try:
-            publish_result_dir(p, remote_root)
+            publish_result_dir(
+                p, remote_root, use_checksums_directory=use_checksums_directory
+            )
 
             num_published += 1
 
@@ -124,7 +133,10 @@ def publish_result_dirs(
 
 
 def publish_result_dir(
-    result_dir: Path, remote_root: PurePath, tries: int = 3
+    result_dir: Path,
+    remote_root: PurePath,
+    tries: int = 3,
+    use_checksums_directory=None,
 ) -> Collection:
     """Publish one Xenium results directory to iRODS.
 
@@ -133,6 +145,7 @@ def publish_result_dir(
         remote_root: iRODS path to the root of the Xenium results collection. This
             collection must exist.
         tries: Number of times to retry publishing if it fails.
+        use_checksums_directory: TODO
 
     Returns:
         The iRODS collection containing the published results.
@@ -145,11 +158,18 @@ def publish_result_dir(
     dest = remote_root / _irods_partial_path(src)
     avus = make_xenium_metadata(src)
 
+    md5sums_path = None
+    checksum_fn: Callable[[Path | str], str] | None = None
+    if use_checksums_directory:
+        md5sums_path = get_md5sums_path(use_checksums_directory, src)
+        checksum_fn = make_get_checksum(md5sums_path)
+
     log.info(
         "Publishing Xenium result",
         src=src.as_posix(),
         dest=dest.as_posix(),
         metadata=avus,
+        md5sums_path=md5sums_path,
     )
 
     def filter_item(item: Path) -> bool:
@@ -160,6 +180,7 @@ def publish_result_dir(
         src,
         dest,
         avus=avus,
+        local_checksum=checksum_fn,
         filter_fn=filter_item,
         force=True,
         fill=True,

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # @author Calum Eadie <ce10@sanger.ac.uk>
-
+import shutil
 from pathlib import Path, PosixPath
 from unittest.mock import patch, MagicMock
 
@@ -83,7 +83,7 @@ class TestChecksum:
 
     @m.context("When checksumming a directory with an existing checksum file")
     @m.it("Creates a checksum file")
-    def test_checksum_directory_no_existing(self, tmp_path):
+    def test_checksum_directory_existing(self, tmp_path):
         # Arrange
         path = Path("./tests/data/simple/collection").absolute()
         md5sums_path = tmp_path / "collection.md5"
@@ -105,7 +105,7 @@ class TestChecksum:
 
     @m.context("When checksum file parent directories missing")
     @m.it("Creates them")
-    def test_checksum_directory_no_existing(self, tmp_path):
+    def test_checksum_directory_parent_missing(self, tmp_path):
         # Arrange
         path = Path("./tests/data/simple/collection").absolute()
         md5sums_path = tmp_path / "missing" / "missing" / "collection.md5"
@@ -115,3 +115,28 @@ class TestChecksum:
 
         # Assert
         assert md5sums_path.exists()
+
+    @m.context(
+        "When checksumming a directory containing a file which is a symbolic link"
+    )
+    @m.it("Skips")
+    def test_checksum_directory_file_sym_link(self, tmp_path):
+        # Arrange
+        path = tmp_path / "collection"
+        path.mkdir()
+        (tmp_path / "a.txt").touch()
+        (path / "b.txt").symlink_to(tmp_path / "a.txt")
+        md5sums_path = tmp_path / "collection.md5"
+
+        # Act
+        num_files, num_checksummed = checksum_directory(path, md5sums_path)
+
+        # Assert
+        assert num_files == 1
+        assert num_checksummed == 0
+        assert (
+            "a.txt" not in md5sums_path.read_text()
+        ), "Path to symbolic link should not appear"
+        assert (
+            "b.txt" not in md5sums_path.read_text()
+        ), "Path to symbolic link destination should not appear"

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -31,9 +31,10 @@ from npg_irods.cli import checksum_directory as checksum_directory_script
 class TestChecksumScript:
 
     @m.context("When run with default parameters only")
+    @m.context("in --md5sums-path mode")
     @m.it("Checksums the directory and outputs the status")
     @patch("npg_irods.cli.checksum_directory.checksum_directory", autospec=True)
-    def test_main_normal_case(
+    def test_main_normal_case_md5sums_path(
         self, mock_checksum_directory: MagicMock, caplog: LogCaptureFixture
     ):
         # Arrange
@@ -47,6 +48,29 @@ class TestChecksumScript:
         mock_checksum_directory.assert_called_once_with(
             PosixPath("directory"),
             PosixPath("md5sums_path"),
+        )
+        assert "Checksummed directory successfully" in caplog.text
+        assert "num_files=2" in caplog.text
+        assert "num_checksummed=1" in caplog.text
+
+    @m.context("When run with default parameters only")
+    @m.context("in --checksums-directory mode")
+    @m.it("Checksums the directory and outputs the status")
+    @patch("npg_irods.cli.checksum_directory.checksum_directory", autospec=True)
+    def test_main_normal_case_checksums_directory(
+        self, mock_checksum_directory: MagicMock, caplog: LogCaptureFixture
+    ):
+        # Arrange
+        mock_checksum_directory.return_value = (2, 1)
+
+        # Act
+        with caplog.at_level("DEBUG"):
+            self._main(["--directory", "/a/b", "--checksums-directory", "/c/d"])
+
+        # Assert
+        mock_checksum_directory.assert_called_once_with(
+            PosixPath("/a/b"),
+            PosixPath("/c/d/a/b.md5"),
         )
         assert "Checksummed directory successfully" in caplog.text
         assert "num_files=2" in caplog.text

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # @author Calum Eadie <ce10@sanger.ac.uk>
-import shutil
+
 from pathlib import Path, PosixPath
 from unittest.mock import patch, MagicMock
 

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -48,7 +48,7 @@ class TestChecksumScript:
             PosixPath("directory"),
             PosixPath("md5sums_path"),
         )
-        assert "Checksummed path successfully" in caplog.text
+        assert "Checksummed directory successfully" in caplog.text
         assert "num_files=2" in caplog.text
         assert "num_checksummed=1" in caplog.text
 
@@ -102,3 +102,16 @@ class TestChecksum:
 92f14d525211301f5ccb1ab6a8884fb3  {path}/sub/b.txt
 """
         )
+
+    @m.context("When checksum file parent directories missing")
+    @m.it("Creates them")
+    def test_checksum_directory_no_existing(self, tmp_path):
+        # Arrange
+        path = Path("./tests/data/simple/collection").absolute()
+        md5sums_path = tmp_path / "missing" / "missing" / "collection.md5"
+
+        # Act
+        checksum_directory(path, md5sums_path)
+
+        # Assert
+        assert md5sums_path.exists()

--- a/tests/xenium/test_publish.py
+++ b/tests/xenium/test_publish.py
@@ -16,19 +16,43 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from pathlib import Path
+from pathlib import Path, PurePath
+from unittest.mock import MagicMock, patch
 
 from partisan.irods import AC, AVU, Collection, Permission
 from pytest import mark as m
 
 from npg_irods.common import PlatformNamespace
-from npg_irods.xenium import publish_result_dir
+from npg_irods.xenium import publish_result_dirs, publish_result_dir
 
 
 class TestPublish:
+
+    @m.context("When publishing a directory fails")
+    @m.it("Reports failure")
+    @patch("npg_irods.xenium.publish_result_dir", autospec=True)
+    def test_publish_result_dirs(self, mock_publish_result_dir: MagicMock):
+        # Arrange
+        reader = ["a", "b"]
+        writer = None
+        remote_root = PurePath("remote_root")
+        use_checksums_directory = False
+
+        mock_publish_result_dir.side_effect = [None, Exception]
+
+        # Act
+        num_dirs, num_published, num_failed = publish_result_dirs(
+            reader, writer, remote_root, use_checksums_directory
+        )
+
+        # Assert
+        assert num_dirs == 2
+        assert num_published == 1
+        assert num_failed == 1
+
     @m.context("When a local Xenium results directory is provided")
     @m.it("Publishes it to iRODS with correct collection metadata")
-    def test_publish_results_directory(self, empty_collection_path):
+    def test_publish_result_dir(self, empty_collection_path):
         local_path = Path(
             "tests/data/xenium/synthetic/"
             "output-XETG00000__0000000__synthetic_region_001__20000101__000000"


### PR DESCRIPTION
Introduces a new checksumming mode - checksums folder - where instead of specifying a checksums file you specify a directory and the tools calculate location of the checksums file within the checksums folder.

Motivated by adopting checksumming in Xenium publishing and not wanting to change the interface of `publish-xenium-results` from accepting directories to publish one per line.