### PR TITLE
checksum-directory: Add Singularity bind troubleshooting

### DIFF
--- a/src/npg_irods/cli/checksum_directory.py
+++ b/src/npg_irods/cli/checksum_directory.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # @author Calum Eadie <ce10@sanger.ac.uk>
+import sys
 
 import argparse
 from pathlib import Path
@@ -85,16 +86,21 @@ def main():
     path = Path(args.directory)
     md5sums_path = Path(args.md5sums_path)
 
-    num_files, num_checksummed = checksum_directory(
-        path,
-        md5sums_path,
-    )
-
-    logger().info(
-        "Checksummed path successfully",
-        num_files=num_files,
-        num_checksummed=num_checksummed,
-    )
+    try:
+        num_files, num_checksummed = checksum_directory(
+            path,
+            md5sums_path,
+        )
+        logger().info(
+            "Checksummed path successfully",
+            num_files=num_files,
+            num_checksummed=num_checksummed,
+        )
+    except FileNotFoundError:
+        logger().exception(
+            "File not found. If you're running under Singularity, check bind configuration (e.g. SINGULARITY_BIND, --bind). This is a common cause.",
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -20,6 +20,7 @@
 from pathlib import Path, PosixPath
 from unittest.mock import patch, MagicMock
 
+import pytest
 from pytest import mark as m
 from pytest import LogCaptureFixture
 
@@ -51,6 +52,22 @@ class TestChecksumScript:
         assert "Checksummed path successfully" in caplog.text
         assert "num_files=2" in caplog.text
         assert "num_checksummed=1" in caplog.text
+
+    @m.context("When encounter file not found")
+    @m.it("Provide SINGULARITY_BIND troubleshooting")
+    def test_main_file_not_found(self, tmp_path, caplog: LogCaptureFixture):
+        # Arrange
+        directory = str(Path("./tests/data/simple/collection").absolute())
+        md5sums_path = str(tmp_path / "missing" / "checksums.md5")
+
+        # Act
+        with caplog.at_level("DEBUG"):
+            with pytest.raises(SystemExit) as system_exit:
+                self._main(["--directory", directory, "--md5sums-path", md5sums_path])
+
+        # Assert
+        assert system_exit.value.code == 1
+        assert "SINGULARITY_BIND" in caplog.text
 
     @staticmethod
     def _main(args: list[str]):


### PR DESCRIPTION
checksum-directory failing due to a missing singularity bind has been a common cause of issues

In particular users have found it hard to diagnose and address the issue. Based on the current error message, they have thought perhaps checksumming had not run and needed to be run ahead of the rnd_platforms publish, that checksumming not working or cache misconfigured

This change guides users towards singularity bind as a common cause

https://jira.sanger.ac.uk/browse/NPG-4188